### PR TITLE
Move dispatch async to pagination

### DIFF
--- a/PVGTableViewProxy/PVGGenericTableViewProxyAnimator.m
+++ b/PVGTableViewProxy/PVGGenericTableViewProxyAnimator.m
@@ -183,17 +183,33 @@ NSString *debugIDFromCellViewModel(id<PVGTableViewCellViewModel> viewModel)
         [newIdsSet addObject:debugID];
     }
     
-    
     if ([newIdsSet count] != [newData count])
     {
         // There are fewer ids in the data set than there are objects -> we have duplicates!
-        NSMutableArray *lastIds = [NSMutableArray array];
+        NSMutableArray<NSString *> *lastIds = [NSMutableArray array];
         for (id<PVGTableViewCellViewModel> viewModel in lastData)
         {
             [lastIds addObject:debugIDFromCellViewModel(viewModel)];
         }
         
-        NSAssert(NO, @"Duplicate ids found when updating table view proxy with last data %@, new data %@", lastIds, newIds);
+        NSMutableDictionary<NSString *, NSNumber *> *counters = [NSMutableDictionary dictionary];
+        for (NSString *debugId in newIds)
+        {
+            NSNumber *counter = counters[debugId] ?: @0;
+            counters[debugId] = @([counter integerValue] + 1);
+        }
+        
+        NSMutableArray<NSString *> *duplicates = [NSMutableArray array];
+        for (NSString *key in counters)
+        {
+            NSNumber *counter = counters[key];
+            if ([counter integerValue] > 1)
+            {
+                [duplicates addObject:[NSString stringWithFormat:@"%@: %@", key, counter]];
+            }
+        }
+        
+        NSAssert(NO, @"Duplicate ids found when updating table view proxy with last data %@, new data %@, counters: %@", lastIds, newIds, duplicates);
     }
 }
 

--- a/PVGTableViewProxy/PVGTableViewProxy.m
+++ b/PVGTableViewProxy/PVGTableViewProxy.m
@@ -322,7 +322,7 @@ static BOOL enableDebugAssertions = NO;
     PVGTableViewSection *section = self.sections[indexPath.section];
     if (indexPath.row + LOAD_MORE_THRESHOLD >= [[section loadedData] count])
     {
-        // We can't to this inline because telling a section to laod more data may trigger an syncronous
+        // We can't do this inline because telling a section to load more data may trigger an syncronous
         // update to the table view in a place where it isn't supported.
         dispatch_async(dispatch_get_main_queue(), ^{
             [section loadMoreData];

--- a/Tests/PVGTableViewProxyTests.xcodeproj/project.pbxproj
+++ b/Tests/PVGTableViewProxyTests.xcodeproj/project.pbxproj
@@ -7,13 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		021A6D2B1BD67739005215A7 /* TableViewProxyLoadMoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D271BD67739005215A7 /* TableViewProxyLoadMoreTests.m */; settings = {ASSET_TAGS = (); }; };
-		021A6D2C1BD67739005215A7 /* TableViewProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D281BD67739005215A7 /* TableViewProxyTests.m */; settings = {ASSET_TAGS = (); }; };
-		021A6D2D1BD67739005215A7 /* TableViewScrollCommandTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */; settings = {ASSET_TAGS = (); }; };
-		021A6D2E1BD67739005215A7 /* TableViewSectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */; settings = {ASSET_TAGS = (); }; };
-		02B7B4361BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m in Sources */ = {isa = PBXBuildFile; fileRef = 02B7B4351BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m */; settings = {ASSET_TAGS = (); }; };
-		02BA88EF1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */; settings = {ASSET_TAGS = (); }; };
-		02E62EDE1BD69F1700BF8EC8 /* MockPVGTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 02E62EDD1BD69F1700BF8EC8 /* MockPVGTableViewCell.m */; settings = {ASSET_TAGS = (); }; };
+		021A6D2B1BD67739005215A7 /* TableViewProxyLoadMoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D271BD67739005215A7 /* TableViewProxyLoadMoreTests.m */; };
+		021A6D2C1BD67739005215A7 /* TableViewProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D281BD67739005215A7 /* TableViewProxyTests.m */; };
+		021A6D2D1BD67739005215A7 /* TableViewScrollCommandTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */; };
+		021A6D2E1BD67739005215A7 /* TableViewSectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */; };
+		027C13D71BE1080800C2C8F5 /* TableViewProxyRenderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 027C13D61BE1080800C2C8F5 /* TableViewProxyRenderTests.m */; };
+		02B7B4361BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m in Sources */ = {isa = PBXBuildFile; fileRef = 02B7B4351BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m */; };
+		02BA88EF1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */; };
+		02E62EDE1BD69F1700BF8EC8 /* MockPVGTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 02E62EDD1BD69F1700BF8EC8 /* MockPVGTableViewCell.m */; };
 		B61F4F719C1E4C05EB0C01D1 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F9DC5FE07A91F2EE454AD62E /* libPods-ios.a */; };
 /* End PBXBuildFile section */
 
@@ -25,6 +26,7 @@
 		021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewScrollCommandTests.m; sourceTree = "<group>"; };
 		021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewSectionTests.m; sourceTree = "<group>"; };
 		021A6D311BD67975005215A7 /* TestDependencies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestDependencies.h; path = "Test Utils/TestDependencies.h"; sourceTree = "<group>"; };
+		027C13D61BE1080800C2C8F5 /* TableViewProxyRenderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewProxyRenderTests.m; sourceTree = "<group>"; };
 		02B7B4341BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MockPVGTableViewCellViewModelDidSelect.h; path = Mocks/MockPVGTableViewCellViewModelDidSelect.h; sourceTree = "<group>"; };
 		02B7B4351BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MockPVGTableViewCellViewModelDidSelect.m; path = Mocks/MockPVGTableViewCellViewModelDidSelect.m; sourceTree = "<group>"; };
 		02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GenericTableViewProxyAnimatorTests.m; sourceTree = "<group>"; };
@@ -72,11 +74,12 @@
 			isa = PBXGroup;
 			children = (
 				02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */,
+				021A6D231BD67725005215A7 /* Info.plist */,
 				021A6D271BD67739005215A7 /* TableViewProxyLoadMoreTests.m */,
+				027C13D61BE1080800C2C8F5 /* TableViewProxyRenderTests.m */,
 				021A6D281BD67739005215A7 /* TableViewProxyTests.m */,
 				021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */,
 				021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */,
-				021A6D231BD67725005215A7 /* Info.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -224,6 +227,7 @@
 				021A6D2E1BD67739005215A7 /* TableViewSectionTests.m in Sources */,
 				02E62EDE1BD69F1700BF8EC8 /* MockPVGTableViewCell.m in Sources */,
 				021A6D2C1BD67739005215A7 /* TableViewProxyTests.m in Sources */,
+				027C13D71BE1080800C2C8F5 /* TableViewProxyRenderTests.m in Sources */,
 				021A6D2B1BD67739005215A7 /* TableViewProxyLoadMoreTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/TableViewProxyLoadMoreTests.m
+++ b/Tests/Tests/TableViewProxyLoadMoreTests.m
@@ -72,6 +72,13 @@
     
     OCMStub([self.mockSection loadedData]).andReturn(data);
     
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Calls loadMoreData on section"];
+    
+    OCMStub([self.mockSection loadMoreData]).andDo(^(NSInvocation *invocation) {
+        [expectation fulfill];
+    });
+    
     PVGTableViewProxy *proxy = [PVGTableViewProxy proxyWithTableView:self.mockTableView
                                                        builder:^(id<PVGTableViewProxyConfig> builder) {
                                                            [builder addSection:self.mockSection atIndex:0];
@@ -82,7 +89,7 @@
     
     [proxy tableView:self.mockTableView willDisplayCell:mockCell forRowAtIndexPath:indexPath];
     
-    OCMVerify([self.mockSection loadMoreData]);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/Tests/Tests/TableViewProxyLoadMoreTests.m
+++ b/Tests/Tests/TableViewProxyLoadMoreTests.m
@@ -72,7 +72,6 @@
     
     OCMStub([self.mockSection loadedData]).andReturn(data);
     
-    
     XCTestExpectation *expectation = [self expectationWithDescription:@"Calls loadMoreData on section"];
     
     OCMStub([self.mockSection loadMoreData]).andDo(^(NSInvocation *invocation) {

--- a/Tests/Tests/TableViewProxyRenderTests.m
+++ b/Tests/Tests/TableViewProxyRenderTests.m
@@ -1,0 +1,105 @@
+//
+//  TableViewProxyRenderTests.m
+//  PVGTableViewProxyTests
+//
+//  Created by Alexander Annas Helgason on 28/10/15.
+//
+//
+
+#import "TestDependencies.h"
+
+#import "PVGTableViewProxy.h"
+#import "PVGTableViewRenderCommand.h"
+
+@interface PVGTableViewProxy (Testing)
+
+@property (readwrite, atomic) NSInteger ongoingScrollAnimations;
+@property (readwrite, atomic) PVGTableViewRenderCommand *pendingRenderCommand;
+
+- (void)executeRenderCommand:(PVGTableViewRenderCommand *)renderCommand;
+
+@end
+
+@interface TableViewProxyRenderTests : XCTestCase
+
+@end
+
+@implementation TableViewProxyRenderTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)test_when_there_are_no_ongoing_scroll_animations_execute_render_will_update_the_table_view
+{
+    NSArray *viewModels = @[OCMProtocolMock(@protocol(PVGTableViewCellViewModel))];
+    PVGTableViewSimpleDataSource *dataSource = [PVGTableViewSimpleDataSource dataSourceWithViewModels:[RACSignal return:viewModels]];
+    PVGTableViewSection *section = [PVGTableViewSection sectionWithDataSource:dataSource];
+    
+    id mockTableView = OCMClassMock([UITableView class]);
+    
+    PVGTableViewProxy *proxy = [PVGTableViewProxy proxyWithTableView:mockTableView
+                                                             builder:^(id<PVGTableViewProxyConfig> newProxy) {
+                                                                 [newProxy addSection:section atIndex:0];
+                                                             }];
+    
+    id mockAnimator = OCMProtocolMock(@protocol(PVGTableViewProxyAnimator));
+    proxy.animator = mockAnimator;
+    
+    
+    PVGTableViewRenderCommand *renderCommand = [PVGTableViewRenderCommand renderCommandForSection:0
+                                                                                       viewModels:viewModels];
+    
+    OCMExpect([mockAnimator animateWithTableView:mockTableView sectionIndex:0 lastData:OCMOCK_ANY newData:OCMOCK_ANY]);
+
+    [proxy executeRenderCommand:renderCommand];
+    
+    OCMVerifyAll(mockAnimator);
+}
+
+- (void)test_when_there_are_ongoing_scroll_animations_then_excecute_render_command_will_store_the_render_command
+{
+    id mockTableView = OCMClassMock([UITableView class]);
+    
+    PVGTableViewProxy *proxy = [PVGTableViewProxy proxyWithTableView:mockTableView
+                                                             builder:^(id<PVGTableViewProxyConfig> newProxy) {
+                                                                 id mockSection = OCMClassMock([PVGTableViewSection class]);
+                                                                 [newProxy addSection:mockSection atIndex:0];
+                                                             }];
+    
+    PVGTableViewRenderCommand *renderCommand = [PVGTableViewRenderCommand renderCommandForSection:0
+                                                                                       viewModels:@[]];
+    
+    
+    proxy.ongoingScrollAnimations = 1;
+    [proxy executeRenderCommand:renderCommand];
+    
+    XCTAssertEqual(renderCommand, proxy.pendingRenderCommand);
+}
+
+- (void)test_when_there_are_ongoing_scroll_animations_then_excecute_render_command_will_not_update_the_table_view
+{
+    id mockTableView = OCMClassMock([UITableView class]);
+    
+    PVGTableViewProxy *proxy = [PVGTableViewProxy proxyWithTableView:mockTableView
+                                                             builder:^(id<PVGTableViewProxyConfig> newProxy) {
+                                                                 id mockSection = OCMClassMock([PVGTableViewSection class]);
+                                                                 [newProxy addSection:mockSection atIndex:0];
+                                                             }];
+    id mockAnimator = OCMProtocolMock(@protocol(PVGTableViewProxyAnimator));
+    proxy.animator = mockAnimator;
+    
+    [[mockAnimator reject] animateWithTableView:mockTableView sectionIndex:0 lastData:OCMOCK_ANY newData:OCMOCK_ANY];
+
+    PVGTableViewRenderCommand *renderCommand = [PVGTableViewRenderCommand renderCommandForSection:0
+                                                                                       viewModels:@[]];
+    
+    
+    proxy.ongoingScrollAnimations = 1;
+    [proxy executeRenderCommand:renderCommand];
+    
+    OCMVerifyAll(mockAnimator);
+}
+
+@end

--- a/Tests/Tests/TableViewProxyTests.m
+++ b/Tests/Tests/TableViewProxyTests.m
@@ -79,11 +79,10 @@
     OCMVerifyAll(mockTableView);
 }
 
-- (void)test_subscribes_to_signal_when_using_builder_and_delivers_on_main_thread
+- (void)test_subscribes_to_signal_when_using_builder
 {
     id mockSignal = OCMClassMock([RACSignal class]);
     OCMExpect([mockSignal ignore:nil]).andReturn(mockSignal);
-    OCMExpect([mockSignal deliverOn:OCMOCK_ANY]).andReturn(mockSignal);
     OCMExpect([mockSignal subscribeNext:OCMOCK_ANY]);
     
     PVGTableViewProxy *proxy = [PVGTableViewProxy proxyWithTableView:nil
@@ -671,6 +670,9 @@
                                                                                 animated:YES
                                                                                 uniqueID:nil];
     
+    OCMExpect([self.mockTableView contentOffset]).andReturn(CGPointMake(0, 0));
+    OCMExpect([self.mockTableView contentOffset]).andReturn(CGPointMake(0, 10));
+    
     XCTAssertTrue([proxy scrollInSection:0 usingCommand:firstCommand]);
     
     @weakify(self)
@@ -708,6 +710,9 @@
     PVGTableViewScrollCommand *firstCommand = [PVGTableViewScrollCommand commandWithType:ScrollCommandTypeBottom
                                                                                 animated:YES
                                                                                 uniqueID:nil];
+    
+    OCMExpect([self.mockTableView contentOffset]).andReturn(CGPointMake(0, 0));
+    OCMExpect([self.mockTableView contentOffset]).andReturn(CGPointMake(0, 10));
     
     XCTAssertTrue([proxy scrollInSection:0 usingCommand:firstCommand]);
     


### PR DESCRIPTION
Passing every update to dispatch_async had a lot of unwanted side-effects. Moving the dispatch_async to only delaying the loadMore on the section allows us to fix the serious bugs without changing the original architecture drastically.