### PR TITLE
PVGViewModels with duplicate unique ids removed

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -14,7 +14,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   PVGTableViewProxy:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   PVGTableViewProxy: f2cd021da863b3c1ea193541c81772bc94356506

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -14,7 +14,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   PVGTableViewProxy:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   PVGTableViewProxy: f2cd021da863b3c1ea193541c81772bc94356506

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -10,13 +10,11 @@
 		00332CEC7EDDFAAF6518C45A94EC84AE /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 846FEBC18EEB572801C921B9311C30A3 /* NSData+RACSupport.m */; };
 		03011BFD1500A28A767DCE9C352BC7B4 /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 40D1DAB6CDF14063CC2EAD478C794D60 /* RACIndexSetSequence.h */; };
 		03AA6DC79A17CE2C4A452320939B72FC /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = DE678BD13584DC6861FEDAE08F442AD5 /* RACQueueScheduler+Subclass.h */; };
-		03CF2EAA5EA36D96268B64842A008865 /* PVGGenericTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = DE6BB8651FE9F0BEEEDEF874118BB9A3 /* PVGGenericTableViewProxyAnimator.m */; };
 		054A1825B481F9C1E0F625873674F3BB /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B7B657408386F64160B789BF97D1BC37 /* NSNotificationCenter+RACSupport.m */; };
 		067A167866956FD155017B6C0D352D08 /* UISegmentedControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DA2747950788C668FEB126121009655 /* UISegmentedControl+RACSignalSupport.h */; };
 		07F926B14EA9709E73A0FD31DC1E91E4 /* UIControl+RACSignalSupportPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EA7F48F074150BCC0456D45734DD775C /* UIControl+RACSignalSupportPrivate.h */; };
 		0895575754ED8B4BE2023A5C98A8ADB5 /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = A598DC9557D3DEF6E8FAEDF22AC94CB3 /* RACKVOChannel.h */; };
 		089E8F2320D3147348FEA0B63EC124A7 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = AEC3894261840901499F87EEBB6054FE /* RACSequence.m */; };
-		0B59E9DB7811CF84B033B3630EC749C7 /* PVGTableViewSectionHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 955C835B284D4113327C553660A29A48 /* PVGTableViewSectionHeader.h */; };
 		0BC890CCDC7980DBF40E048662C325E1 /* UISlider+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E52DFB8D644239658D299590B6B65E12 /* UISlider+RACSignalSupport.h */; };
 		0BE3092432D63B258EE8F2C6D3EA44A4 /* UIActionSheet+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 8698798B5EDB069C55026FDAD48DD9FD /* UIActionSheet+RACSignalSupport.h */; };
 		0C8ADD2446C4622CB1012F00225F437C /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC4A47CB27400CE3F4D3D5F2A85E30F /* RACKVOChannel.m */; };
@@ -34,15 +32,17 @@
 		151BA60747C60C27F2FCF101362C105A /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AEF1A37504F52691DAA2195D8901F8D4 /* NSOrderedSet+RACSequenceAdditions.h */; };
 		15A5F637AA6278FFD472125CEA31FF64 /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 645C0AF40ACADF2D65ED38896502C3D8 /* RACSignal.h */; };
 		15CB96F3ADB1BE34610F5D5F3EB6C22A /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D8372EF52C94F036D02155DEE13E4E9 /* RACTestScheduler.m */; };
+		16B368967B1B25BF200A8A970A9A4CC4 /* PVGTableViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B671C4463ADD99221023B982E82723 /* PVGTableViewProxy.m */; };
 		16C5010A199AF5C01D460B125E0306DD /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DC49A0E76C3FCF6B9347A71847445BD /* UITextView+RACSignalSupport.m */; };
 		1870C9910D9D17DA500849A36566D9A1 /* UIRefreshControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F28C851A91A9877DB8589C7770E48B37 /* UIRefreshControl+RACCommandSupport.h */; };
 		188DB40F47F21EF196FFE52E286D5CD9 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = AD51D875EFE9D59C4C349E11359CA076 /* RACMulticastConnection.h */; };
-		1AE261EC740C9A3780CAA31D3012FDBC /* PVGTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = F8610FBF78A0E38A897C2450CF703C59 /* PVGTableViewCell.h */; };
 		1B68CDE2DF4F483995C1A0AB75D1996E /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 731CB8BBB296456F60B763EC89FD783D /* RACValueTransformer.h */; };
 		1B87AF24D2ED137E1E690B071793D6F2 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = 30A58A95231750AE3DE0DC3B8A11EEFA /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		1BDA21CD1CF31E3C8D4A926DE26E6F5E /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 296CA51B2F256933F26B3B5C3A26FA53 /* RACStream.m */; };
 		1BE3D8A59B9913DB759D8A398F2610C4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
-		1C1645B2C287C4B47B85F70170BA3E43 /* PVGTableViewSimpleDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C88E577F0316EE446C3F4D4FD8C28D /* PVGTableViewSimpleDataSource.h */; };
+		1C5E94ED93BDEA60BC05BCF644E19CA4 /* PVGTableViewProxy-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 155080946302CCC34A5BBD2BA004AAC1 /* PVGTableViewProxy-dummy.m */; };
+		1D60D6DA206ED4087A8EC4342D30DEE2 /* PVGTableViewSectionHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B8C4596444694D8D244635D6F6D0691 /* PVGTableViewSectionHeader.h */; };
+		1F3CD5B4FAA3962D6C707FDC3AB12034 /* PVGTableViewSectionHeaderViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F2A28D88AD562C46FB7CF0AFDF9BD75A /* PVGTableViewSectionHeaderViewModel.h */; };
 		2093A312BFA3CA886D8F6A75537A8A22 /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = E8BDBE95107A32FC97E09AB9B81D4867 /* RACCommand.h */; };
 		239F0600239776FA204CD324D2656099 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 05DA6A0485F05A5B8FAC9C5075F24C25 /* RACChannel.m */; };
 		241970783CB71FCA2AACEACD772CF225 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B4C933FECE1CDE00719BAD43AFB2287 /* NSObject+RACPropertySubscribing.h */; };
@@ -54,7 +54,7 @@
 		2BF721F3B6409DC62DD9FE753884AF60 /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F23D47FC49F17706B3704B858F641474 /* RACDynamicSignal.h */; };
 		2D8D9C72FDD849A05E8B46ADC6D8372C /* UISegmentedControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7C64A873FC015EA2E645EE434E095C /* UISegmentedControl+RACSignalSupport.m */; };
 		2E4E52E4AF14E658B0FC72EDDA428879 /* UIControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 1714237768AAB0EC3A967506B4F7661B /* UIControl+RACSignalSupport.m */; };
-		2F21E0D71938D685C255AFB48D9C00C5 /* PVGTableViewScrollCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D5B22561CD4AEC8E7D86F0EF6DD2727 /* PVGTableViewScrollCommand.h */; };
+		2EC864D0E755BF5232451F18DB679989 /* PVGTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 05B0CABB3EBC8F429597180EF85A0F6D /* PVGTableViewProxyAnimator.h */; };
 		2F32074B19910E80757DAB385C5B6273 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = C7AD4041B478EC9005BF39A02B58A4E3 /* RACSubscriptionScheduler.h */; };
 		2F48FB1CB51096D571D222C6B8802BF8 /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 922263689244BB247089E56E21317FF1 /* RACSubject.h */; };
 		2FD647A29A3E6BDBDD6517FF3CF72F65 /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = C9B9F39DDBF6B63AB196496F5034FF08 /* RACReturnSignal.m */; };
@@ -63,12 +63,11 @@
 		343B490FAB7C2548AAEDE0702B8FAD10 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C840289F27A924A639BB7C62FABA37 /* RACSignalSequence.m */; };
 		36B8E6C3DE38395FD96C4A71E410D72E /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5737BBD1CFF4039AD73963350B299022 /* NSEnumerator+RACSequenceAdditions.m */; };
 		39FD155B1AF87868DDE7B8575C2141B8 /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C1FFA45553D64C3E27A733F051019268 /* NSString+RACSequenceAdditions.m */; };
-		3BCB0CB9B8EADDDD779ADEFCBB6D0992 /* PVGTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = C1E7AEF144BB6B3261C33BB8FB85395C /* PVGTableViewProxyAnimator.h */; };
 		3CABCF061ED07E1185CE425D349D453C /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 342812A379B74454B8C6795EF46E1C5A /* RACStringSequence.h */; };
 		3CD3052927509A8DC5093E2DC93DDCAE /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AB0F51FEC409855C488EF1E6DD4121E7 /* NSSet+RACSequenceAdditions.h */; };
 		3D2C2FDA75B2A5E389367D48694A6FE6 /* UITextField+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 107BCE9D092A1D899BEF69F6F0F81C42 /* UITextField+RACSignalSupport.m */; };
-		3D99935B0F00EEC008B2741501CB2FD5 /* PVGTableViewCellViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 28A0DADF6E593A26460390180379351E /* PVGTableViewCellViewModel.h */; };
 		3DE80EF9B5992C99283390164D6ACB79 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = C4160E68CB759E94BDAB661004118D35 /* NSObject+RACKVOWrapper.m */; };
+		3DF24DB626E37A829D154AF751DB1ACD /* PVGTableViewRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A82D5EB35AE380F440FCE80169B38E /* PVGTableViewRenderCommand.m */; };
 		3EEA542EC7FA1A065D97EF71AA792F4C /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 771971D9207A05ACF42A8AD2E5A83E5F /* RACSubscriptingAssignmentTrampoline.h */; };
 		3F8FEE411AE0A00240DCE05A25B5A419 /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 21EA8575483C4E7C762146F6B054CE29 /* NSObject+RACDescription.h */; };
 		40AD1EB9CC4F21C6914A9E7DE70DB1D9 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B69520299977F607F84A81182091D9A /* NSIndexSet+RACSequenceAdditions.h */; };
@@ -77,7 +76,6 @@
 		47942EE56BDAB34C243E1326AB6923C4 /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C6E02D3672EE4F0EDDA287FF97B27CBA /* NSURLConnection+RACSupport.m */; };
 		4AA8EFB4C30E060BBFD085F72C876CCA /* UITableViewCell+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 408F15843246F81454926FFC1A797BBE /* UITableViewCell+RACSignalSupport.m */; };
 		4B53B998A3D31B0C322911114B7B4C00 /* UIStepper+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = ADFFA519A388AEA9CCB9063946D66E43 /* UIStepper+RACSignalSupport.h */; };
-		4BA1CA0D77F60F4BC58997D4948A49F4 /* PVGNoAnimationTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B09BD37B7784F47C10849B8BC994EA6 /* PVGNoAnimationTableViewProxyAnimator.m */; };
 		4C439E761AF867E12AFE6B01E59C0B29 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F6E2259805A58291730DE532888E5F /* RACEmptySequence.h */; };
 		4E467062038DA35D4F26A1EE80F647EA /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AEAEB396263AA772F3936110FB61EF /* NSFileHandle+RACSupport.m */; };
 		4E7EC8D2C7413949F91C46D9C99269AA /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5FE25266576E81064842138A0F7F41 /* RACReplaySubject.m */; };
@@ -90,7 +88,6 @@
 		52AC3D8AC4F540DF9986F00E2CBA636C /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D6A21C4DB7151B0D39E6B5F65B68E5F /* RACUnarySequence.m */; };
 		53F0E9B7D3D09E1FF2A4E539D464EEBD /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CEDE813274E5575E4CE20ECBF73370E /* RACmetamacros.h */; };
 		593F21399A82840D9D708BD5982B3708 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 69A2B75A66C6D250737F21FE802C8337 /* RACSignal+Operations.h */; };
-		5A1FEA7E7AEF2C927FF840EFC37C8347 /* PVGTableViewProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 08B3AEC8AADA4C8C3EB66D41AD4148AB /* PVGTableViewProxy.h */; };
 		5A3BC186ADC3600C11AEF64F7721C223 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 74D72D0D9FF1D63D92ABEC391EC2DDBE /* RACCompoundDisposable.m */; };
 		5A63CFF97EEA60D4B8681FC371BA5CAF /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = B9B383D316786CD1F391BDAF26040D91 /* NSObject+RACDeallocating.h */; };
 		5A658B3703D7E74C052A7376CCFF5EE8 /* UIRefreshControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CABBD98A1A74904C9B7ABC6391F9F507 /* UIRefreshControl+RACCommandSupport.m */; };
@@ -107,18 +104,17 @@
 		67E9A5CFC175F935A3B3035C2A2B1A8D /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = CA816BF237380D6C013E347D3A95E25F /* RACKVOTrampoline.h */; };
 		68A909A451AEB17B4E899F08F5E74D4C /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 900BC67AA21628CE6BEE96A6E18AEF5A /* RACSignal+Operations.m */; };
 		695783CBF9EB0D4819EEDD8EDB1FFA96 /* UISwitch+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D7D3076151A27E89C1B7411F17D0A044 /* UISwitch+RACSignalSupport.h */; };
-		6A300CF5AF1D9086EF8FFCD18537B558 /* PVGNoAnimationTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2038CD51AEF9D33B234FF1BA3CD85E7A /* PVGNoAnimationTableViewProxyAnimator.h */; };
 		6BBC8EDDDDE85911EC85FCD43C488EE5 /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = C42B679F61566B57FA6B2781E6DA8A8E /* RACSubscriptionScheduler.m */; };
+		6BBDBCA737D4E0A837D94004C13F3FD1 /* PVGNoAnimationTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD39B83FF57F26C3FA90770CE364867 /* PVGNoAnimationTableViewProxyAnimator.h */; };
 		6BE7F5A985C699B103D0EA47752671FD /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = E3A39A7A183EF6E9D7BEBC2429C21825 /* RACBlockTrampoline.m */; };
 		6C67E8C72475FFEBB2BE5F88DC73CA41 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3299EB0CC2186A382407C37816F8FAE2 /* RACSignal.m */; };
-		6CF494938F289326CE70F91D9EB896B3 /* PVGTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 520DB13B2D28BB462FD92D724A15A4D8 /* PVGTableViewDataSource.h */; };
+		6EA7B2D04D4BDCA32579365FFC8BCD8F /* PVGGenericTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E987B4E97BD9A87A5257406698FAE9 /* PVGGenericTableViewProxyAnimator.h */; };
 		6F25CAFA83E8910F78C06901678127AA /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EFAFB57EE6CA3C122D820FA12685EB9 /* RACEagerSequence.h */; };
-		710145738A85825381A1615EFF2866E4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
 		7263665F8ECD1BAD463DF1242EFFFA8E /* UICollectionReusableView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B475DCFED9543168A2F07B243488CAC4 /* UICollectionReusableView+RACSignalSupport.m */; };
 		7264B3DF7A62BE9B7B46F9933937A056 /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B44EC76FDF9737D11822F9CDA575050 /* RACDynamicSignal.m */; };
-		739507349342B8965D8449610A75B567 /* PVGTableViewRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CF18DB6CCC2ED906A1BBC3AAE4320BE /* PVGTableViewRenderCommand.m */; };
-		73D0F0F197F014AD95E401C72CF277E7 /* PVGTableViewSectionHeaderViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = A2DBE2BABC9DF601152D5CF8A1A523B1 /* PVGTableViewSectionHeaderViewModel.m */; };
+		7351E9CF492141AB5ABE54A09C679007 /* PVGTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = AC59922AE528D62F2D055A3D48272160 /* PVGTableViewDataSource.h */; };
 		754F624E0D0FBF189A69F6799DCC24D4 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F3AC4553E14CBF18E3BD1879BDE94 /* RACTupleSequence.h */; };
+		766A769D1E79444EDE841C5D32A35254 /* PVGTableViewSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E150B4D0FA0A5213AF9164441943C06 /* PVGTableViewSection.h */; };
 		76B2E76C5A9DDCB14C7BBEFD296E9C2B /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = 33063C9A08401D48D6C482292EE133C2 /* NSObject+RACDeallocating.m */; };
 		77C469AADA42AA132609766DEBE28237 /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CFB6FE4324556C92D21674A06D7E061B /* NSUserDefaults+RACSupport.m */; };
 		785EC6939BE636890A51460603035DD1 /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 14364E67A96C8BD16262072B28967C56 /* UIGestureRecognizer+RACSignalSupport.m */; };
@@ -127,7 +123,9 @@
 		7DBBF4A0E4D2CD2AA156A385556CE56C /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B8CFC154A95428B7ED73537D260054 /* NSString+RACSupport.h */; };
 		7F51DA91D7CD1E2ABD0598B70E0AFB73 /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FF2B4C40E6B53880C8E24B78B0F7832 /* RACBehaviorSubject.h */; };
 		7FC3C078D1A66C0B8EE0365666ED4F80 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 6F579BA21AB650D4151C5A94A6C9510D /* RACSignalProvider.d */; };
+		819424D0CCDDB2C3EA271BC14C82F948 /* PVGTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 1050A8DCDF518F819BA69795C7B395B9 /* PVGTableViewCell.h */; };
 		81D62A3651B389463793439339C6EBA0 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B00CD4796DC365642F1FD6FD66D1C72 /* NSNotificationCenter+RACSupport.h */; };
+		8251A193B396E99C4AE11FE2DE33E53F /* PVGTableViewScrollCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 74B1616DBCEE591E67047EF18EEB2D96 /* PVGTableViewScrollCommand.h */; };
 		825BF245A5EB227FCDA98A5B7498FDEA /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = CF64DA3BCFEF64CBB8DF761F8F5402C2 /* RACEvent.m */; };
 		8268F3D8F7DB695E29345321A6C76372 /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F942752256CBB49E0E90309B9E68FDD4 /* RACReturnSignal.h */; };
 		82BC3D96733EC9F01A1DDD3F79AD2E2A /* UISwitch+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 353D1E1A8915739C7FF0F6B0A46E1561 /* UISwitch+RACSignalSupport.m */; };
@@ -136,23 +134,28 @@
 		846DF3B4ADA557334C1601F188D0FFC5 /* UIControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = BA97C73028E4F2C19682DC3F5D1F03CA /* UIControl+RACSignalSupport.h */; };
 		84D878F725843E3F33F5AD72176A6882 /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 79AB581354056E317CBCE93A9C1291AD /* RACSubscriber+Private.h */; };
 		850E9B89EC01FCDADBFDE97E55737240 /* UIGestureRecognizer+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = C5B8D17F7061AEB62F9F624A83C4C7F9 /* UIGestureRecognizer+RACSignalSupport.h */; };
+		85172E15B0507D8F11B6F9F279E3F681 /* PVGTableViewProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DDCE7943297C4627ECD2FCE211E9817D /* PVGTableViewProxy.h */; };
 		8541CA714B2DC02E190CFE4189D7A85C /* UIButton+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B9AC99B7A572727A615B770954ECE19 /* UIButton+RACCommandSupport.m */; };
 		85E973FB60A07A9E6F5253B35F6851D4 /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CE54CE749F5963EC960FCA05DCA6CCA1 /* NSDictionary+RACSequenceAdditions.h */; };
+		867B622D86440B794736E20DDE01B6FC /* PVGNoAnimationTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = E0EC6E390E3894098354CD28BA7E6D4E /* PVGNoAnimationTableViewProxyAnimator.m */; };
 		88E54DAB4929F93E93B931797E534A48 /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF8F5CC10D35B3E8FDAD293BFDAE207 /* RACEXTRuntimeExtensions.h */; };
 		88E9DEEB28360B932BB7D91E5F31C293 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A306134FA1B70D83AC83C8A45D54287 /* NSString+RACKeyPathUtilities.h */; };
 		8A44600A9C335C4C2DF8F8E1512EA02D /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 50CCFF25C487E8C2A2C4305939BD58D9 /* RACScheduler+Private.h */; };
 		8B2797C3A800C089EA0C7AAFFED630B4 /* UITableViewCell+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 02785933B4E28BB3A0F7EB65005B6543 /* UITableViewCell+RACSignalSupport.h */; };
 		8E091F9730391E8389864F5D95311331 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = C051B5B2DCB50742A9CE431F104A17FC /* RACChannel.h */; };
+		8FD9B12BF207349D03B2645C77F20047 /* PVGTableViewCellViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = F1C37B168A9AABB00A59321DEAF37DC0 /* PVGTableViewCellViewModel.h */; };
 		906230112BA6E4D1440349A55C1BC340 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A69E5C3ED170CC8296A92329C486422 /* NSString+RACKeyPathUtilities.m */; };
-		90F9287A329E123E49B3A233E0E991A9 /* PVGTableViewSimpleDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 89BD02230F7D5E0E93A3C7AA4A7BAF87 /* PVGTableViewSimpleDataSource.m */; };
+		93CAE6647E7031278C94D26E528FABB1 /* PVGTableViewSectionHeaderViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C9D350C47B0816FE199089FE12CA01A1 /* PVGTableViewSectionHeaderViewModel.m */; };
 		95C420B62360223D8687D9E6AD22D5D5 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F9668BCC293FA91F76BBB9D9BD5B17E3 /* NSArray+RACSequenceAdditions.h */; };
-		9719B488BE1B873F9F6D6B0B68CAAE4F /* PVGTableViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7482C4DB5D3CBCD1ED5827DF7D80D4CA /* PVGTableViewProxy.m */; };
+		98041E01773DEE7C937F218CC8727D31 /* PVGGenericTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2FD3D20D738DE99FEBF0F6857D0BA8 /* PVGGenericTableViewProxyAnimator.m */; };
+		98D2CBE4761925FE93E2396B4A39A512 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
 		9A007674725B1A416486D680C300AAF0 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = B076AD76C51CAE345ADE64C725E37ED4 /* RACDynamicSequence.h */; };
 		9A7E04364A64AB6E124B2864A12C9B49 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = D094E57D368A25D9785043D14346E254 /* RACUnit.h */; };
+		9B85C6981A6C827AF64A660ADEA964EA /* PVGTableViewSimpleDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = F31D09A709C40D64062884E7987A478E /* PVGTableViewSimpleDataSource.m */; };
 		9B9C0C9FDC1CC7AFFE009A101C1718D7 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D971A7F99B391957EBC3C7C9A418100 /* NSSet+RACSequenceAdditions.m */; };
 		9BAD2597C9F01BFB1A69BC423C229C98 /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C9FA62836DA791757618E53B24EB50D /* RACStringSequence.m */; };
+		9C394BF05CF322754E4413DD54EDD168 /* PVGTableViewScrollCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E0FE103C1B2DC841C99B440B073E435 /* PVGTableViewScrollCommand.m */; };
 		9E2A20B9F889593653EA8CBA3AD87869 /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B6C5B13EFFD7476F70161C7123B8CBB /* RACErrorSignal.m */; };
-		9F518F09E170E8E7D03BF61FD3D9E545 /* PVGTableViewSectionHeaderViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 156913FD71A71BF66B0A6CD441AD714A /* PVGTableViewSectionHeaderViewModel.h */; };
 		A01D7E94498F1F43429F6EB2895EE758 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = CC2FB81E1B89680A4005722F5018EB59 /* RACArraySequence.m */; };
 		A045F5CE0D8EE93A53CA83B5E4744ECD /* UISlider+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A1495F15F92FA9D1EE7E55F1CA9396DC /* UISlider+RACSignalSupport.m */; };
 		A2217F2160C4B98278B8917E6EB6B2C9 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 86B4BAD96208433567D0BFDBA577439D /* NSObject+RACSelectorSignal.m */; };
@@ -162,6 +165,7 @@
 		A5FBAD1AC3CF04455E93826C8CB1B99B /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B399772008DA02172F1A21DE7CB43214 /* NSFileHandle+RACSupport.h */; };
 		A6DCD312EC3279A85919A7AEA042BBCA /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E215CC4EE877C62E49E6983E041361B /* RACSequence.h */; };
 		A6E0219509E05CE4EDC6AD0AE2A2C14B /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 31F807C0A440095BF5E8916186F429AB /* RACValueTransformer.m */; };
+		A9085584D5CE60D5A2C3450A90DA4FBC /* PVGTableViewRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DA95C0663F9961502618F8726ACA13B /* PVGTableViewRenderCommand.h */; };
 		A933D3D11D7A2E6BC803DEA8CAEB5F2B /* UIImagePickerController+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 0655F30CB9735CB13177D82A33382D91 /* UIImagePickerController+RACSignalSupport.m */; };
 		AF892D6AA9F35B0B47A6237C151B1613 /* UIButton+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A999A7F538AF8A4862AC71F53E83065 /* UIButton+RACCommandSupport.h */; };
 		B0FCBB76A7B658E1F441384AED06A346 /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = E76F89C06792BF0EDC548B2B7A0A7D15 /* NSInvocation+RACTypeParsing.h */; };
@@ -170,12 +174,10 @@
 		B2F3502E0B1BD3E34803E7FA2A12BD28 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD8DC0DC65D0F996708F553A03833A1 /* UITableViewHeaderFooterView+RACSignalSupport.h */; };
 		B3D0F935F984049151E80233FDCC1114 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = C02DD7524C315129FCDD763AC77D048A /* RACDelegateProxy.h */; };
 		B5DA8E438E68F6EB0582D837B6670BCF /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A95FBBA33A0F0F59621803314BCB125 /* NSEnumerator+RACSequenceAdditions.h */; };
-		B8531E1782ECAFDF47BCF961D6AABB26 /* PVGTableViewSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 804DE70AF1806BF6D4DD745B82050061 /* PVGTableViewSection.h */; };
+		B9F807F67402082E504D7E15CB540D78 /* PVGTableViewSection.m in Sources */ = {isa = PBXBuildFile; fileRef = D89F56D97344BEF46614E5D2F3C3A94B /* PVGTableViewSection.m */; };
 		BDF222AE5324324E5E4792E347A58CB3 /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CE6A88CE9D0A2AB63F299F0B80F2089 /* RACEvent.h */; };
-		BE2CE80085CC5E30C8BEB8418DD8AACA /* PVGGenericTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D126034923A1D5A6C1EA37F426296DB /* PVGGenericTableViewProxyAnimator.h */; };
 		BEAA43B78AFF9B7446094B5B3511D86E /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EBA69C679002AA860824339E3400F8A /* NSArray+RACSequenceAdditions.m */; };
 		C394EED60161BA240A45E12EFBFF8550 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = C7BB4A4237288DC19952B04736193816 /* RACKVOTrampoline.m */; };
-		C4A8EA75D7E30C7846E36C142FA9D2EE /* PVGTableViewScrollCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = C34FF69E433B0FB7C321B45F5D928712 /* PVGTableViewScrollCommand.m */; };
 		C5537A973E0FD8DCA03B2C41CE91B909 /* RACBacktrace.h in Headers */ = {isa = PBXBuildFile; fileRef = 926ABBD47DCDA26015F4BAB18F6025CF /* RACBacktrace.h */; };
 		C71311E45A5C71192B2E69F0F2510B57 /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A6C5E34582AAE79B79B143134BED9612 /* NSString+RACSequenceAdditions.h */; };
 		C758A06810E4052E2B504E7237D793BE /* UIControl+RACSignalSupportPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C92717480FEAF693210016E7577CB2 /* UIControl+RACSignalSupportPrivate.m */; };
@@ -186,7 +188,6 @@
 		CEAE611C4F976A908C9BF7D494C87CC9 /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = F3E5702AC9C4052BEB95C01C7BC40DC4 /* RACImmediateScheduler.h */; };
 		CEB826D08ADF207D069DD80629845EEB /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DD156ADF2D9401C4C5BD02FDABBFA31 /* NSObject+RACPropertySubscribing.m */; };
 		D20060AD4776A5BE36A813CA4DF438D8 /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A19127A8973D028E4CB60C290D97B8F /* RACScheduler+Subclass.h */; };
-		D403A9AEFBAB5929B65EBAE3166381CF /* PVGTableViewRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 4553C6606DF691A232FA6C418A99461F /* PVGTableViewRenderCommand.h */; };
 		D4EBCCD3E477673068C6F1B9FFB32DB9 /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D957B9EAF06986CD15C18E2F0E3DBCD /* RACGroupedSignal.h */; };
 		D59B8B02B2EFDBF22621C451CDA1E430 /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FDFDF782B84EFEF2CE89D503C2EE962 /* RACQueueScheduler.m */; };
 		D5D9AABE9BE92A96444434FEFD4F8D6D /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D80BD19BCD22037F8B73C012EC4F5DF /* UIBarButtonItem+RACCommandSupport.h */; };
@@ -198,6 +199,7 @@
 		D9C188214F02DE82F6D0468B971326F0 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 27005B8A5393DF069A5059187D9DF227 /* RACSerialDisposable.m */; };
 		DA6026789EBF5712EFEB71D11B89172A /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 176C0445EBE470950F5B52CBC8452FF5 /* NSDictionary+RACSequenceAdditions.m */; };
 		DB91D9F96B54A1969E2A4D7296399C27 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 7877E00898EDDB5D0AD57F58A27668E5 /* RACScopedDisposable.m */; };
+		DDBD3C3CDB136283F09057EE57325B29 /* PVGTableViewSimpleDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DA2906A39B4B3A8DA2B5F9271355EB97 /* PVGTableViewSimpleDataSource.h */; };
 		DE14896FD4216D47AD1FA0E7B5DA7988 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = C625CD9258C8B36AF99D5B25F47FEF28 /* RACCompoundDisposable.h */; };
 		DE8848DD25BA2BCA5D75DA69E547F7F3 /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BDDE1D3B38723CD008A41CD27A17CA3 /* NSObject+RACLifting.m */; };
 		DF731034A7914A95BB3B940B82411FBA /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FA4B1555B6736205E12913A690024 /* RACMulticastConnection.m */; };
@@ -211,76 +213,74 @@
 		EA830E3C2A886BCC82901B332EF0F28E /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 35FB5B163C46BD845176B87D265CA5D8 /* RACQueueScheduler.h */; };
 		EFA06C72F7C6E379118AC955E3E04E47 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = C7CBD7D718CEE3FE4466BF512532C1A3 /* RACEXTKeyPathCoding.h */; };
 		F14B0BFD13510DF64D388E17EDDB3A2F /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = FC042EB387C07EB55D8EAAEBFC2ED404 /* RACScheduler.h */; };
-		F24B07965937DFD518280770243393AD /* PVGTableViewSection.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D2364248213B8AFD65F3B824C0CE755 /* PVGTableViewSection.m */; };
 		F2AAA11DCDBDCC768ABF27D779D427F4 /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = 54BE4609363ED029180FE0B4A8EF57F2 /* NSInvocation+RACTypeParsing.m */; };
 		F6FFF2AB993351B02B411D8A670800E9 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F1C37132F4CD4AED2917B637E30FB7EA /* RACErrorSignal.h */; };
 		F7A062628CA8F8CA90E27CCEA1D4D3EB /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 783DC67ECE66449CD7937CFC153F9642 /* RACDelegateProxy.m */; };
 		F7BF57A10083343FDF7DE28F15B0DDF9 /* UIStepper+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 15FC13C66436EE6D1E3C82A8A53353D7 /* UIStepper+RACSignalSupport.m */; };
 		F86BA441CF4B25C47FE9AF11460B37C3 /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 94471863AFA368A15D8BCD5ABD0205AB /* RACEmptySignal.h */; };
 		FACC60021354E0AD1BAC251D434D42C3 /* UITextField+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D54D194720BA374E3DC61A6073D013A5 /* UITextField+RACSignalSupport.h */; };
-		FBD3C27B3D55B650DAAA30837DE0BB56 /* PVGTableViewProxy-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D1E270F664654B63D274EDDDD93D2E80 /* PVGTableViewProxy-dummy.m */; };
 		FE1B95AF4DAC0F2A5AA524D1B7D980CB /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = C1637E266C84A46C65B270D7F380B304 /* RACPassthroughSubscriber.m */; };
 		FE7C3909004BEA9C134E333343B6D004 /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAB52083E14D6178D64FAA27E7DB6A /* RACScopedDisposable.h */; };
 		FF1278E2502DA8298B576FBF9FED6546 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 083D8C547CE2BB0A1A1B117300539383 /* UIBarButtonItem+RACCommandSupport.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		42D081440C4DB5E84321C3D688CB2E9D /* PBXContainerItemProxy */ = {
+		9140BBEBB7B3C15366B37509237A03C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 02E0E782B528F3966A5430E15671F8D0;
+			remoteGlobalIDString = D76319C99A3017CFE90D0DE010012BAD;
+			remoteInfo = ReactiveCocoa;
+		};
+		914D098C142CF1841728630AA26FA6D3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D76319C99A3017CFE90D0DE010012BAD;
+			remoteInfo = ReactiveCocoa;
+		};
+		E2AA3AEC9CEB29925765EC3BD9B5E50F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 62231171C8B9A0C2DE60B9DAC7AACA79;
 			remoteInfo = PVGTableViewProxy;
-		};
-		4C232C6F85855182932E4AF15DB842C3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D76319C99A3017CFE90D0DE010012BAD;
-			remoteInfo = ReactiveCocoa;
-		};
-		89B265FE05475A5ACD18487E635F4B72 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D76319C99A3017CFE90D0DE010012BAD;
-			remoteInfo = ReactiveCocoa;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		02785933B4E28BB3A0F7EB65005B6543 /* UITableViewCell+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewCell+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.h"; sourceTree = "<group>"; };
 		0313CA92A67C11509BC7D9B90344D6B7 /* NSURLConnection+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+RACSupport.h"; path = "ReactiveCocoa/NSURLConnection+RACSupport.h"; sourceTree = "<group>"; };
+		04A82D5EB35AE380F440FCE80169B38E /* PVGTableViewRenderCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewRenderCommand.m; sourceTree = "<group>"; };
+		05B0CABB3EBC8F429597180EF85A0F6D /* PVGTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		05DA6A0485F05A5B8FAC9C5075F24C25 /* RACChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACChannel.m; path = ReactiveCocoa/RACChannel.m; sourceTree = "<group>"; };
 		0655F30CB9735CB13177D82A33382D91 /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImagePickerController+RACSignalSupport.m"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
 		07AEAEB396263AA772F3936110FB61EF /* NSFileHandle+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileHandle+RACSupport.m"; path = "ReactiveCocoa/NSFileHandle+RACSupport.m"; sourceTree = "<group>"; };
 		07C840289F27A924A639BB7C62FABA37 /* RACSignalSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignalSequence.m; path = ReactiveCocoa/RACSignalSequence.m; sourceTree = "<group>"; };
 		083D8C547CE2BB0A1A1B117300539383 /* UIBarButtonItem+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIBarButtonItem+RACCommandSupport.m"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m"; sourceTree = "<group>"; };
-		08B3AEC8AADA4C8C3EB66D41AD4148AB /* PVGTableViewProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxy.h; sourceTree = "<group>"; };
 		0A69E5C3ED170CC8296A92329C486422 /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = "<group>"; };
+		0B8C4596444694D8D244635D6F6D0691 /* PVGTableViewSectionHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeader.h; sourceTree = "<group>"; };
 		0D045C21D82F2FAED64A072CD9C1392A /* RACImmediateScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = ReactiveCocoa/RACImmediateScheduler.m; sourceTree = "<group>"; };
 		0DD156ADF2D9401C4C5BD02FDABBFA31 /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = "<group>"; };
+		0E150B4D0FA0A5213AF9164441943C06 /* PVGTableViewSection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSection.h; sourceTree = "<group>"; };
 		0E215CC4EE877C62E49E6983E041361B /* RACSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSequence.h; path = ReactiveCocoa/RACSequence.h; sourceTree = "<group>"; };
 		0FE629FEFD8701CFC7E220B7E4F51EC2 /* RACEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTScope.h; path = ReactiveCocoa/extobjc/RACEXTScope.h; sourceTree = "<group>"; };
+		1050A8DCDF518F819BA69795C7B395B9 /* PVGTableViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCell.h; sourceTree = "<group>"; };
 		107BCE9D092A1D899BEF69F6F0F81C42 /* UITextField+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextField+RACSignalSupport.m"; path = "ReactiveCocoa/UITextField+RACSignalSupport.m"; sourceTree = "<group>"; };
 		11C92717480FEAF693210016E7577CB2 /* UIControl+RACSignalSupportPrivate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupportPrivate.m"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.m"; sourceTree = "<group>"; };
 		14364E67A96C8BD16262072B28967C56 /* UIGestureRecognizer+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIGestureRecognizer+RACSignalSupport.m"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m"; sourceTree = "<group>"; };
 		14D58BB3CC94BC995F1EF50A538DA6C9 /* RACDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = ReactiveCocoa/RACDisposable.m; sourceTree = "<group>"; };
-		156913FD71A71BF66B0A6CD441AD714A /* PVGTableViewSectionHeaderViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeaderViewModel.h; sourceTree = "<group>"; };
+		155080946302CCC34A5BBD2BA004AAC1 /* PVGTableViewProxy-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PVGTableViewProxy-dummy.m"; sourceTree = "<group>"; };
 		15FC13C66436EE6D1E3C82A8A53353D7 /* UIStepper+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIStepper+RACSignalSupport.m"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.m"; sourceTree = "<group>"; };
 		1714237768AAB0EC3A967506B4F7661B /* UIControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupport.m"; path = "ReactiveCocoa/UIControl+RACSignalSupport.m"; sourceTree = "<group>"; };
 		176C0445EBE470950F5B52CBC8452FF5 /* NSDictionary+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		198F5B20B991C69949391F16658913E3 /* PVGTableViewProxy-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "PVGTableViewProxy-Private.xcconfig"; sourceTree = "<group>"; };
 		1AA0B7DB5F9861FFD6C54337DD42736D /* RACSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = ReactiveCocoa/RACSubscriber.m; sourceTree = "<group>"; };
-		1B09BD37B7784F47C10849B8BC994EA6 /* PVGNoAnimationTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGNoAnimationTableViewProxyAnimator.m; sourceTree = "<group>"; };
 		1DA2747950788C668FEB126121009655 /* UISegmentedControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISegmentedControl+RACSignalSupport.h"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.h"; sourceTree = "<group>"; };
 		1FD8DC0DC65D0F996708F553A03833A1 /* UITableViewHeaderFooterView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewHeaderFooterView+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		1FEC710239369B368D4B6D086A0A5A68 /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = "<group>"; };
-		2038CD51AEF9D33B234FF1BA3CD85E7A /* PVGNoAnimationTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGNoAnimationTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		217D2210909C9815A7F677E56C73A869 /* RACMulticastConnection+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACMulticastConnection+Private.h"; path = "ReactiveCocoa/RACMulticastConnection+Private.h"; sourceTree = "<group>"; };
 		21EA8575483C4E7C762146F6B054CE29 /* NSObject+RACDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDescription.h"; path = "ReactiveCocoa/NSObject+RACDescription.h"; sourceTree = "<group>"; };
 		27005B8A5393DF069A5059187D9DF227 /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = ReactiveCocoa/RACSerialDisposable.m; sourceTree = "<group>"; };
-		28A0DADF6E593A26460390180379351E /* PVGTableViewCellViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCellViewModel.h; sourceTree = "<group>"; };
 		296CA51B2F256933F26B3B5C3A26FA53 /* RACStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = ReactiveCocoa/RACStream.m; sourceTree = "<group>"; };
 		29FAB52083E14D6178D64FAA27E7DB6A /* RACScopedDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScopedDisposable.h; path = ReactiveCocoa/RACScopedDisposable.h; sourceTree = "<group>"; };
 		2A19127A8973D028E4CB60C290D97B8F /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
@@ -313,17 +313,14 @@
 		40D1DAB6CDF14063CC2EAD478C794D60 /* RACIndexSetSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACIndexSetSequence.h; path = ReactiveCocoa/RACIndexSetSequence.h; sourceTree = "<group>"; };
 		430B51A6F3628BC3B45B84F3D857CC87 /* NSObject+RACKVOWrapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACKVOWrapper.h"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.h"; sourceTree = "<group>"; };
 		44E7B2550C3A8A462DD244E6CA66ACB8 /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptingAssignmentTrampoline.m; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
-		4553C6606DF691A232FA6C418A99461F /* PVGTableViewRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewRenderCommand.h; sourceTree = "<group>"; };
 		494D7DE7A5FDFA83B75B1BE6BF3380BB /* UIDatePicker+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIDatePicker+RACSignalSupport.m"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.m"; sourceTree = "<group>"; };
+		4A2FD3D20D738DE99FEBF0F6857D0BA8 /* PVGGenericTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGGenericTableViewProxyAnimator.m; sourceTree = "<group>"; };
 		4A5FE25266576E81064842138A0F7F41 /* RACReplaySubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = ReactiveCocoa/RACReplaySubject.m; sourceTree = "<group>"; };
-		4CC3B178C094FA1530EDA46FE4E58777 /* libPVGTableViewProxy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPVGTableViewProxy.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4D5B22561CD4AEC8E7D86F0EF6DD2727 /* PVGTableViewScrollCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewScrollCommand.h; sourceTree = "<group>"; };
 		4DBD56CF9E167F05817698096206D758 /* Pods-PVGTableViewProxyExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PVGTableViewProxyExample-acknowledgements.plist"; sourceTree = "<group>"; };
 		4ED2D85CEBC801B17B542A20C4586B6B /* NSData+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+RACSupport.h"; path = "ReactiveCocoa/NSData+RACSupport.h"; sourceTree = "<group>"; };
 		4FF2B4C40E6B53880C8E24B78B0F7832 /* RACBehaviorSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBehaviorSubject.h; path = ReactiveCocoa/RACBehaviorSubject.h; sourceTree = "<group>"; };
 		50CCFF25C487E8C2A2C4305939BD58D9 /* RACScheduler+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Private.h"; path = "ReactiveCocoa/RACScheduler+Private.h"; sourceTree = "<group>"; };
 		50CD25838196EF77602DC8A2D9AB669F /* NSObject+RACSelectorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACSelectorSignal.h"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.h"; sourceTree = "<group>"; };
-		520DB13B2D28BB462FD92D724A15A4D8 /* PVGTableViewDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewDataSource.h; sourceTree = "<group>"; };
 		54BE4609363ED029180FE0B4A8EF57F2 /* NSInvocation+RACTypeParsing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+RACTypeParsing.m"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.m"; sourceTree = "<group>"; };
 		5517A57176B320EC954CF564804715AE /* UIActionSheet+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+RACSignalSupport.m"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.m"; sourceTree = "<group>"; };
 		5737BBD1CFF4039AD73963350B299022 /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = "<group>"; };
@@ -342,15 +339,18 @@
 		6A95FBBA33A0F0F59621803314BCB125 /* NSEnumerator+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSEnumerator+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		6A999A7F538AF8A4862AC71F53E83065 /* UIButton+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+RACCommandSupport.h"; path = "ReactiveCocoa/UIButton+RACCommandSupport.h"; sourceTree = "<group>"; };
 		6B9AC99B7A572727A615B770954ECE19 /* UIButton+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+RACCommandSupport.m"; path = "ReactiveCocoa/UIButton+RACCommandSupport.m"; sourceTree = "<group>"; };
+		6BD39B83FF57F26C3FA90770CE364867 /* PVGNoAnimationTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGNoAnimationTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		6BF0AAA55C2645A59FBF9F230F4AA3C8 /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = "<group>"; };
 		6CE6A88CE9D0A2AB63F299F0B80F2089 /* RACEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEvent.h; path = ReactiveCocoa/RACEvent.h; sourceTree = "<group>"; };
+		6E0FE103C1B2DC841C99B440B073E435 /* PVGTableViewScrollCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewScrollCommand.m; sourceTree = "<group>"; };
 		6EAFD6A656782B190787DD25C3236CBD /* PVGTableViewProxy-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PVGTableViewProxy-prefix.pch"; sourceTree = "<group>"; };
 		6EBA69C679002AA860824339E3400F8A /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		6F11CF6EBC7A2DCFC77E4FE96D426F75 /* RACTupleSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = ReactiveCocoa/RACTupleSequence.m; sourceTree = "<group>"; };
 		6F579BA21AB650D4151C5A94A6C9510D /* RACSignalProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = ReactiveCocoa/RACSignalProvider.d; sourceTree = "<group>"; };
 		71E77D7D48EB5122040103F293EC2478 /* RACEagerSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = ReactiveCocoa/RACEagerSequence.m; sourceTree = "<group>"; };
 		731CB8BBB296456F60B763EC89FD783D /* RACValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACValueTransformer.h; path = ReactiveCocoa/RACValueTransformer.h; sourceTree = "<group>"; };
-		7482C4DB5D3CBCD1ED5827DF7D80D4CA /* PVGTableViewProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewProxy.m; sourceTree = "<group>"; };
+		7463661F2733D7C3DB857381E05EA4A2 /* libPVGTableViewProxy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPVGTableViewProxy.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		74B1616DBCEE591E67047EF18EEB2D96 /* PVGTableViewScrollCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewScrollCommand.h; sourceTree = "<group>"; };
 		74D72D0D9FF1D63D92ABEC391EC2DDBE /* RACCompoundDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = ReactiveCocoa/RACCompoundDisposable.m; sourceTree = "<group>"; };
 		75776330A6272A4E85526BE63F0DECAA /* NSIndexSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSIndexSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		771971D9207A05ACF42A8AD2E5A83E5F /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptingAssignmentTrampoline.h; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
@@ -359,18 +359,16 @@
 		7877E00898EDDB5D0AD57F58A27668E5 /* RACScopedDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = ReactiveCocoa/RACScopedDisposable.m; sourceTree = "<group>"; };
 		79AB581354056E317CBCE93A9C1291AD /* RACSubscriber+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSubscriber+Private.h"; path = "ReactiveCocoa/RACSubscriber+Private.h"; sourceTree = "<group>"; };
 		7B69520299977F607F84A81182091D9A /* NSIndexSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSIndexSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		7D2364248213B8AFD65F3B824C0CE755 /* PVGTableViewSection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSection.m; sourceTree = "<group>"; };
 		7D703EDFB35859B1E860BA2AA2F8A5ED /* libPods-PVGTableViewProxyExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PVGTableViewProxyExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D80BD19BCD22037F8B73C012EC4F5DF /* UIBarButtonItem+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIBarButtonItem+RACCommandSupport.h"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h"; sourceTree = "<group>"; };
+		7DA95C0663F9961502618F8726ACA13B /* PVGTableViewRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewRenderCommand.h; sourceTree = "<group>"; };
 		7FB2EB56A627C51DDF3DCB5479770A97 /* RACScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = ReactiveCocoa/RACScheduler.m; sourceTree = "<group>"; };
 		7FDFDF782B84EFEF2CE89D503C2EE962 /* RACQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = ReactiveCocoa/RACQueueScheduler.m; sourceTree = "<group>"; };
-		804DE70AF1806BF6D4DD745B82050061 /* PVGTableViewSection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSection.h; sourceTree = "<group>"; };
 		8108647BC465B08C2BBD676A46BDDA2C /* NSOrderedSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSOrderedSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		82EF5CAD58DF6BD48DFAC5FF9D19742D /* RACDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDisposable.h; path = ReactiveCocoa/RACDisposable.h; sourceTree = "<group>"; };
 		846FEBC18EEB572801C921B9311C30A3 /* NSData+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+RACSupport.m"; path = "ReactiveCocoa/NSData+RACSupport.m"; sourceTree = "<group>"; };
 		8698798B5EDB069C55026FDAD48DD9FD /* UIActionSheet+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+RACSignalSupport.h"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.h"; sourceTree = "<group>"; };
 		86B4BAD96208433567D0BFDBA577439D /* NSObject+RACSelectorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACSelectorSignal.m"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.m"; sourceTree = "<group>"; };
-		89BD02230F7D5E0E93A3C7AA4A7BAF87 /* PVGTableViewSimpleDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSimpleDataSource.m; sourceTree = "<group>"; };
 		8B8FA4B1555B6736205E12913A690024 /* RACMulticastConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = ReactiveCocoa/RACMulticastConnection.m; sourceTree = "<group>"; };
 		8CEDE813274E5575E4CE20ECBF73370E /* RACmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACmetamacros.h; path = ReactiveCocoa/extobjc/RACmetamacros.h; sourceTree = "<group>"; };
 		8CF8F5CC10D35B3E8FDAD293BFDAE207 /* RACEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTRuntimeExtensions.h; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.h; sourceTree = "<group>"; };
@@ -383,14 +381,10 @@
 		926ABBD47DCDA26015F4BAB18F6025CF /* RACBacktrace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBacktrace.h; path = ReactiveCocoa/RACBacktrace.h; sourceTree = "<group>"; };
 		943B7A7C1C19279F7B6D77DA3569A9F1 /* ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
 		94471863AFA368A15D8BCD5ABD0205AB /* RACEmptySignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySignal.h; path = ReactiveCocoa/RACEmptySignal.h; sourceTree = "<group>"; };
-		955C835B284D4113327C553660A29A48 /* PVGTableViewSectionHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeader.h; sourceTree = "<group>"; };
 		95875C0920F9EC19B8FA7F5A96FA23EE /* RACSignalSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignalSequence.h; path = ReactiveCocoa/RACSignalSequence.h; sourceTree = "<group>"; };
 		9C9FA62836DA791757618E53B24EB50D /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = ReactiveCocoa/RACStringSequence.m; sourceTree = "<group>"; };
-		9CF18DB6CCC2ED906A1BBC3AAE4320BE /* PVGTableViewRenderCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewRenderCommand.m; sourceTree = "<group>"; };
-		9D126034923A1D5A6C1EA37F426296DB /* PVGGenericTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGGenericTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		9D8372EF52C94F036D02155DEE13E4E9 /* RACTestScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTestScheduler.m; path = ReactiveCocoa/RACTestScheduler.m; sourceTree = "<group>"; };
 		A1495F15F92FA9D1EE7E55F1CA9396DC /* UISlider+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISlider+RACSignalSupport.m"; path = "ReactiveCocoa/UISlider+RACSignalSupport.m"; sourceTree = "<group>"; };
-		A2DBE2BABC9DF601152D5CF8A1A523B1 /* PVGTableViewSectionHeaderViewModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSectionHeaderViewModel.m; sourceTree = "<group>"; };
 		A364F4B47B0AD3047B148D67BDAB3564 /* RACReplaySubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReplaySubject.h; path = ReactiveCocoa/RACReplaySubject.h; sourceTree = "<group>"; };
 		A43F590B5C69E2876E2A29EA8942D8DB /* libReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactiveCocoa.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A598DC9557D3DEF6E8FAEDF22AC94CB3 /* RACKVOChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOChannel.h; path = ReactiveCocoa/RACKVOChannel.h; sourceTree = "<group>"; };
@@ -398,6 +392,7 @@
 		A7171A4E88A6FED634A66E6FB5DEA29F /* UIAlertView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+RACSignalSupport.m"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		A850C7D90295015311FE93C23EAF93A8 /* RACGroupedSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = ReactiveCocoa/RACGroupedSignal.m; sourceTree = "<group>"; };
 		AB0F51FEC409855C488EF1E6DD4121E7 /* NSSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		AC59922AE528D62F2D055A3D48272160 /* PVGTableViewDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewDataSource.h; sourceTree = "<group>"; };
 		AC6CF20EE234ECC0603F0E712DF9CB1F /* RACBacktrace.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBacktrace.m; path = ReactiveCocoa/RACBacktrace.m; sourceTree = "<group>"; };
 		AD51D875EFE9D59C4C349E11359CA076 /* RACMulticastConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACMulticastConnection.h; path = ReactiveCocoa/RACMulticastConnection.h; sourceTree = "<group>"; };
 		ADFFA519A388AEA9CCB9063946D66E43 /* UIStepper+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIStepper+RACSignalSupport.h"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.h"; sourceTree = "<group>"; };
@@ -409,6 +404,7 @@
 		B399772008DA02172F1A21DE7CB43214 /* NSFileHandle+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileHandle+RACSupport.h"; path = "ReactiveCocoa/NSFileHandle+RACSupport.h"; sourceTree = "<group>"; };
 		B3B11C192C0B046402E0FAAACBE01FD2 /* RACSerialDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSerialDisposable.h; path = ReactiveCocoa/RACSerialDisposable.h; sourceTree = "<group>"; };
 		B475DCFED9543168A2F07B243488CAC4 /* UICollectionReusableView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UICollectionReusableView+RACSignalSupport.m"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		B6B671C4463ADD99221023B982E82723 /* PVGTableViewProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewProxy.m; sourceTree = "<group>"; };
 		B7B657408386F64160B789BF97D1BC37 /* NSNotificationCenter+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+RACSupport.m"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.m"; sourceTree = "<group>"; };
 		B9B383D316786CD1F391BDAF26040D91 /* NSObject+RACDeallocating.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDeallocating.h"; path = "ReactiveCocoa/NSObject+RACDeallocating.h"; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -419,9 +415,7 @@
 		C051B5B2DCB50742A9CE431F104A17FC /* RACChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACChannel.h; path = ReactiveCocoa/RACChannel.h; sourceTree = "<group>"; };
 		C117572C729C85B7FFB3B3008B883DC4 /* NSString+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSupport.m"; path = "ReactiveCocoa/NSString+RACSupport.m"; sourceTree = "<group>"; };
 		C1637E266C84A46C65B270D7F380B304 /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = "<group>"; };
-		C1E7AEF144BB6B3261C33BB8FB85395C /* PVGTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		C1FFA45553D64C3E27A733F051019268 /* NSString+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		C34FF69E433B0FB7C321B45F5D928712 /* PVGTableViewScrollCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewScrollCommand.m; sourceTree = "<group>"; };
 		C4160E68CB759E94BDAB661004118D35 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = "<group>"; };
 		C42B679F61566B57FA6B2781E6DA8A8E /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = "<group>"; };
 		C59D6FB68DDFB619171281D2757B6300 /* RACObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACObjCRuntime.h; path = ReactiveCocoa/RACObjCRuntime.h; sourceTree = "<group>"; };
@@ -434,6 +428,7 @@
 		C8770B93A7AAC90292717828E109773D /* RACStream+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACStream+Private.h"; path = "ReactiveCocoa/RACStream+Private.h"; sourceTree = "<group>"; };
 		C97EFC6BB3F7B44668F64A38E130E992 /* NSObject+RACLifting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACLifting.h"; path = "ReactiveCocoa/NSObject+RACLifting.h"; sourceTree = "<group>"; };
 		C9B9F39DDBF6B63AB196496F5034FF08 /* RACReturnSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = ReactiveCocoa/RACReturnSignal.m; sourceTree = "<group>"; };
+		C9D350C47B0816FE199089FE12CA01A1 /* PVGTableViewSectionHeaderViewModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSectionHeaderViewModel.m; sourceTree = "<group>"; };
 		CA816BF237380D6C013E347D3A95E25F /* RACKVOTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOTrampoline.h; path = ReactiveCocoa/RACKVOTrampoline.h; sourceTree = "<group>"; };
 		CABBD98A1A74904C9B7ABC6391F9F507 /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+RACCommandSupport.m"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
 		CC2FB81E1B89680A4005722F5018EB59 /* RACArraySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = ReactiveCocoa/RACArraySequence.m; sourceTree = "<group>"; };
@@ -442,23 +437,26 @@
 		CF64DA3BCFEF64CBB8DF761F8F5402C2 /* RACEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = ReactiveCocoa/RACEvent.m; sourceTree = "<group>"; };
 		CFB6FE4324556C92D21674A06D7E061B /* NSUserDefaults+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+RACSupport.m"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.m"; sourceTree = "<group>"; };
 		D094E57D368A25D9785043D14346E254 /* RACUnit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnit.h; path = ReactiveCocoa/RACUnit.h; sourceTree = "<group>"; };
-		D0C88E577F0316EE446C3F4D4FD8C28D /* PVGTableViewSimpleDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSimpleDataSource.h; sourceTree = "<group>"; };
 		D0F6E2259805A58291730DE532888E5F /* RACEmptySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySequence.h; path = ReactiveCocoa/RACEmptySequence.h; sourceTree = "<group>"; };
-		D1E270F664654B63D274EDDDD93D2E80 /* PVGTableViewProxy-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PVGTableViewProxy-dummy.m"; sourceTree = "<group>"; };
 		D54D194720BA374E3DC61A6073D013A5 /* UITextField+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextField+RACSignalSupport.h"; path = "ReactiveCocoa/UITextField+RACSignalSupport.h"; sourceTree = "<group>"; };
 		D7D3076151A27E89C1B7411F17D0A044 /* UISwitch+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISwitch+RACSignalSupport.h"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.h"; sourceTree = "<group>"; };
 		D85CBE5913099006F39EAAE594E35C38 /* RACDynamicSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = ReactiveCocoa/RACDynamicSequence.m; sourceTree = "<group>"; };
+		D89F56D97344BEF46614E5D2F3C3A94B /* PVGTableViewSection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSection.m; sourceTree = "<group>"; };
 		D9A0FBA9023422C48C6C4C4E7FA7E6F4 /* RACCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = ReactiveCocoa/RACCommand.m; sourceTree = "<group>"; };
+		DA2906A39B4B3A8DA2B5F9271355EB97 /* PVGTableViewSimpleDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSimpleDataSource.h; sourceTree = "<group>"; };
 		DC6EA08A346B8970E9699719604B50C8 /* RACSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriber.h; path = ReactiveCocoa/RACSubscriber.h; sourceTree = "<group>"; };
+		DDCE7943297C4627ECD2FCE211E9817D /* PVGTableViewProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxy.h; sourceTree = "<group>"; };
 		DE678BD13584DC6861FEDAE08F442AD5 /* RACQueueScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACQueueScheduler+Subclass.h"; path = "ReactiveCocoa/RACQueueScheduler+Subclass.h"; sourceTree = "<group>"; };
-		DE6BB8651FE9F0BEEEDEF874118BB9A3 /* PVGGenericTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGGenericTableViewProxyAnimator.m; sourceTree = "<group>"; };
 		DF6945BEEEC3B9F1B9EED33342882867 /* PVGTableViewProxy.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PVGTableViewProxy.xcconfig; sourceTree = "<group>"; };
+		E0537CD933CE6FA2C39CCB63ED5AC82F /* PVGTableViewProxy-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "PVGTableViewProxy-Private.xcconfig"; sourceTree = "<group>"; };
+		E0EC6E390E3894098354CD28BA7E6D4E /* PVGNoAnimationTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGNoAnimationTableViewProxyAnimator.m; sourceTree = "<group>"; };
 		E3A39A7A183EF6E9D7BEBC2429C21825 /* RACBlockTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = ReactiveCocoa/RACBlockTrampoline.m; sourceTree = "<group>"; };
 		E52DFB8D644239658D299590B6B65E12 /* UISlider+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISlider+RACSignalSupport.h"; path = "ReactiveCocoa/UISlider+RACSignalSupport.h"; sourceTree = "<group>"; };
 		E64DEE7671C48F3BD6C6171701043F20 /* Pods-PVGTableViewProxyExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PVGTableViewProxyExample-dummy.m"; sourceTree = "<group>"; };
 		E705372F9D2AAA8D6E04603A240F05EE /* NSObject+RACDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = "<group>"; };
 		E76F89C06792BF0EDC548B2B7A0A7D15 /* NSInvocation+RACTypeParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+RACTypeParsing.h"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.h"; sourceTree = "<group>"; };
 		E8BDBE95107A32FC97E09AB9B81D4867 /* RACCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCommand.h; path = ReactiveCocoa/RACCommand.h; sourceTree = "<group>"; };
+		E8E987B4E97BD9A87A5257406698FAE9 /* PVGGenericTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGGenericTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		E9D743CFCA3AE9B69424FAA2EA6626DD /* Pods-PVGTableViewProxyExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PVGTableViewProxyExample.release.xcconfig"; sourceTree = "<group>"; };
 		EA7F48F074150BCC0456D45734DD775C /* UIControl+RACSignalSupportPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupportPrivate.h"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.h"; sourceTree = "<group>"; };
 		EBA7B516077276B80C35ACDC7ABEFFB0 /* RACEmptySignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = ReactiveCocoa/RACEmptySignal.m; sourceTree = "<group>"; };
@@ -466,12 +464,14 @@
 		ED01142D790FA1F8AEA4F866568DDEC1 /* RACTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = ReactiveCocoa/RACTuple.m; sourceTree = "<group>"; };
 		F04136BF91AD100D150F35F616C52370 /* ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ReactiveCocoa.xcconfig; sourceTree = "<group>"; };
 		F1C37132F4CD4AED2917B637E30FB7EA /* RACErrorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACErrorSignal.h; path = ReactiveCocoa/RACErrorSignal.h; sourceTree = "<group>"; };
+		F1C37B168A9AABB00A59321DEAF37DC0 /* PVGTableViewCellViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCellViewModel.h; sourceTree = "<group>"; };
 		F23D47FC49F17706B3704B858F641474 /* RACDynamicSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSignal.h; path = ReactiveCocoa/RACDynamicSignal.h; sourceTree = "<group>"; };
 		F28C851A91A9877DB8589C7770E48B37 /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+RACCommandSupport.h"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
+		F2A28D88AD562C46FB7CF0AFDF9BD75A /* PVGTableViewSectionHeaderViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeaderViewModel.h; sourceTree = "<group>"; };
+		F31D09A709C40D64062884E7987A478E /* PVGTableViewSimpleDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSimpleDataSource.m; sourceTree = "<group>"; };
 		F3C26030EFFE911458D6BDEA7D67BE5B /* RACIndexSetSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACIndexSetSequence.m; path = ReactiveCocoa/RACIndexSetSequence.m; sourceTree = "<group>"; };
 		F3E5702AC9C4052BEB95C01C7BC40DC4 /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = ReactiveCocoa/RACImmediateScheduler.h; sourceTree = "<group>"; };
 		F6589A44A1689815B788906281BD2858 /* UIAlertView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+RACSignalSupport.h"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		F8610FBF78A0E38A897C2450CF703C59 /* PVGTableViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCell.h; sourceTree = "<group>"; };
 		F942752256CBB49E0E90309B9E68FDD4 /* RACReturnSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReturnSignal.h; path = ReactiveCocoa/RACReturnSignal.h; sourceTree = "<group>"; };
 		F9668BCC293FA91F76BBB9D9BD5B17E3 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		FC042EB387C07EB55D8EAAEBFC2ED404 /* RACScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScheduler.h; path = ReactiveCocoa/RACScheduler.h; sourceTree = "<group>"; };
@@ -488,11 +488,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BA5FB10DFA7BE2F62E3E80733A5AFC8F /* Frameworks */ = {
+		5B9AD2B7B65DF14A762307A8A73EE875 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				710145738A85825381A1615EFF2866E4 /* Foundation.framework in Frameworks */,
+				98D2CBE4761925FE93E2396B4A39A512 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -556,8 +556,8 @@
 			isa = PBXGroup;
 			children = (
 				DF6945BEEEC3B9F1B9EED33342882867 /* PVGTableViewProxy.xcconfig */,
-				198F5B20B991C69949391F16658913E3 /* PVGTableViewProxy-Private.xcconfig */,
-				D1E270F664654B63D274EDDDD93D2E80 /* PVGTableViewProxy-dummy.m */,
+				E0537CD933CE6FA2C39CCB63ED5AC82F /* PVGTableViewProxy-Private.xcconfig */,
+				155080946302CCC34A5BBD2BA004AAC1 /* PVGTableViewProxy-dummy.m */,
 				6EAFD6A656782B190787DD25C3236CBD /* PVGTableViewProxy-prefix.pch */,
 			);
 			name = "Support Files";
@@ -800,27 +800,27 @@
 		C0717258ED825440CD090FFEA8C5FDBB /* PVGTableViewProxy */ = {
 			isa = PBXGroup;
 			children = (
-				9D126034923A1D5A6C1EA37F426296DB /* PVGGenericTableViewProxyAnimator.h */,
-				DE6BB8651FE9F0BEEEDEF874118BB9A3 /* PVGGenericTableViewProxyAnimator.m */,
-				2038CD51AEF9D33B234FF1BA3CD85E7A /* PVGNoAnimationTableViewProxyAnimator.h */,
-				1B09BD37B7784F47C10849B8BC994EA6 /* PVGNoAnimationTableViewProxyAnimator.m */,
-				F8610FBF78A0E38A897C2450CF703C59 /* PVGTableViewCell.h */,
-				28A0DADF6E593A26460390180379351E /* PVGTableViewCellViewModel.h */,
-				520DB13B2D28BB462FD92D724A15A4D8 /* PVGTableViewDataSource.h */,
-				08B3AEC8AADA4C8C3EB66D41AD4148AB /* PVGTableViewProxy.h */,
-				7482C4DB5D3CBCD1ED5827DF7D80D4CA /* PVGTableViewProxy.m */,
-				C1E7AEF144BB6B3261C33BB8FB85395C /* PVGTableViewProxyAnimator.h */,
-				4553C6606DF691A232FA6C418A99461F /* PVGTableViewRenderCommand.h */,
-				9CF18DB6CCC2ED906A1BBC3AAE4320BE /* PVGTableViewRenderCommand.m */,
-				4D5B22561CD4AEC8E7D86F0EF6DD2727 /* PVGTableViewScrollCommand.h */,
-				C34FF69E433B0FB7C321B45F5D928712 /* PVGTableViewScrollCommand.m */,
-				804DE70AF1806BF6D4DD745B82050061 /* PVGTableViewSection.h */,
-				7D2364248213B8AFD65F3B824C0CE755 /* PVGTableViewSection.m */,
-				955C835B284D4113327C553660A29A48 /* PVGTableViewSectionHeader.h */,
-				156913FD71A71BF66B0A6CD441AD714A /* PVGTableViewSectionHeaderViewModel.h */,
-				A2DBE2BABC9DF601152D5CF8A1A523B1 /* PVGTableViewSectionHeaderViewModel.m */,
-				D0C88E577F0316EE446C3F4D4FD8C28D /* PVGTableViewSimpleDataSource.h */,
-				89BD02230F7D5E0E93A3C7AA4A7BAF87 /* PVGTableViewSimpleDataSource.m */,
+				E8E987B4E97BD9A87A5257406698FAE9 /* PVGGenericTableViewProxyAnimator.h */,
+				4A2FD3D20D738DE99FEBF0F6857D0BA8 /* PVGGenericTableViewProxyAnimator.m */,
+				6BD39B83FF57F26C3FA90770CE364867 /* PVGNoAnimationTableViewProxyAnimator.h */,
+				E0EC6E390E3894098354CD28BA7E6D4E /* PVGNoAnimationTableViewProxyAnimator.m */,
+				1050A8DCDF518F819BA69795C7B395B9 /* PVGTableViewCell.h */,
+				F1C37B168A9AABB00A59321DEAF37DC0 /* PVGTableViewCellViewModel.h */,
+				AC59922AE528D62F2D055A3D48272160 /* PVGTableViewDataSource.h */,
+				DDCE7943297C4627ECD2FCE211E9817D /* PVGTableViewProxy.h */,
+				B6B671C4463ADD99221023B982E82723 /* PVGTableViewProxy.m */,
+				05B0CABB3EBC8F429597180EF85A0F6D /* PVGTableViewProxyAnimator.h */,
+				7DA95C0663F9961502618F8726ACA13B /* PVGTableViewRenderCommand.h */,
+				04A82D5EB35AE380F440FCE80169B38E /* PVGTableViewRenderCommand.m */,
+				74B1616DBCEE591E67047EF18EEB2D96 /* PVGTableViewScrollCommand.h */,
+				6E0FE103C1B2DC841C99B440B073E435 /* PVGTableViewScrollCommand.m */,
+				0E150B4D0FA0A5213AF9164441943C06 /* PVGTableViewSection.h */,
+				D89F56D97344BEF46614E5D2F3C3A94B /* PVGTableViewSection.m */,
+				0B8C4596444694D8D244635D6F6D0691 /* PVGTableViewSectionHeader.h */,
+				F2A28D88AD562C46FB7CF0AFDF9BD75A /* PVGTableViewSectionHeaderViewModel.h */,
+				C9D350C47B0816FE199089FE12CA01A1 /* PVGTableViewSectionHeaderViewModel.m */,
+				DA2906A39B4B3A8DA2B5F9271355EB97 /* PVGTableViewSimpleDataSource.h */,
+				F31D09A709C40D64062884E7987A478E /* PVGTableViewSimpleDataSource.m */,
 			);
 			path = PVGTableViewProxy;
 			sourceTree = "<group>";
@@ -828,7 +828,7 @@
 		CCA510CFBEA2D207524CDA0D73C3B561 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				4CC3B178C094FA1530EDA46FE4E58777 /* libPVGTableViewProxy.a */,
+				7463661F2733D7C3DB857381E05EA4A2 /* libPVGTableViewProxy.a */,
 				7D703EDFB35859B1E860BA2AA2F8A5ED /* libPods-PVGTableViewProxyExample.a */,
 				A43F590B5C69E2876E2A29EA8942D8DB /* libReactiveCocoa.a */,
 			);
@@ -973,45 +973,45 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DFA22B378CD5F8F32E791DE18868FE0C /* Headers */ = {
+		51ED09E583E3F03FD0A3532445EBE210 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE2CE80085CC5E30C8BEB8418DD8AACA /* PVGGenericTableViewProxyAnimator.h in Headers */,
-				6A300CF5AF1D9086EF8FFCD18537B558 /* PVGNoAnimationTableViewProxyAnimator.h in Headers */,
-				1AE261EC740C9A3780CAA31D3012FDBC /* PVGTableViewCell.h in Headers */,
-				3D99935B0F00EEC008B2741501CB2FD5 /* PVGTableViewCellViewModel.h in Headers */,
-				6CF494938F289326CE70F91D9EB896B3 /* PVGTableViewDataSource.h in Headers */,
-				5A1FEA7E7AEF2C927FF840EFC37C8347 /* PVGTableViewProxy.h in Headers */,
-				3BCB0CB9B8EADDDD779ADEFCBB6D0992 /* PVGTableViewProxyAnimator.h in Headers */,
-				D403A9AEFBAB5929B65EBAE3166381CF /* PVGTableViewRenderCommand.h in Headers */,
-				2F21E0D71938D685C255AFB48D9C00C5 /* PVGTableViewScrollCommand.h in Headers */,
-				B8531E1782ECAFDF47BCF961D6AABB26 /* PVGTableViewSection.h in Headers */,
-				0B59E9DB7811CF84B033B3630EC749C7 /* PVGTableViewSectionHeader.h in Headers */,
-				9F518F09E170E8E7D03BF61FD3D9E545 /* PVGTableViewSectionHeaderViewModel.h in Headers */,
-				1C1645B2C287C4B47B85F70170BA3E43 /* PVGTableViewSimpleDataSource.h in Headers */,
+				6EA7B2D04D4BDCA32579365FFC8BCD8F /* PVGGenericTableViewProxyAnimator.h in Headers */,
+				6BBDBCA737D4E0A837D94004C13F3FD1 /* PVGNoAnimationTableViewProxyAnimator.h in Headers */,
+				819424D0CCDDB2C3EA271BC14C82F948 /* PVGTableViewCell.h in Headers */,
+				8FD9B12BF207349D03B2645C77F20047 /* PVGTableViewCellViewModel.h in Headers */,
+				7351E9CF492141AB5ABE54A09C679007 /* PVGTableViewDataSource.h in Headers */,
+				85172E15B0507D8F11B6F9F279E3F681 /* PVGTableViewProxy.h in Headers */,
+				2EC864D0E755BF5232451F18DB679989 /* PVGTableViewProxyAnimator.h in Headers */,
+				A9085584D5CE60D5A2C3450A90DA4FBC /* PVGTableViewRenderCommand.h in Headers */,
+				8251A193B396E99C4AE11FE2DE33E53F /* PVGTableViewScrollCommand.h in Headers */,
+				766A769D1E79444EDE841C5D32A35254 /* PVGTableViewSection.h in Headers */,
+				1D60D6DA206ED4087A8EC4342D30DEE2 /* PVGTableViewSectionHeader.h in Headers */,
+				1F3CD5B4FAA3962D6C707FDC3AB12034 /* PVGTableViewSectionHeaderViewModel.h in Headers */,
+				DDBD3C3CDB136283F09057EE57325B29 /* PVGTableViewSimpleDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		02E0E782B528F3966A5430E15671F8D0 /* PVGTableViewProxy */ = {
+		62231171C8B9A0C2DE60B9DAC7AACA79 /* PVGTableViewProxy */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C7E67073F1544797373B2C61B1F20837 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */;
+			buildConfigurationList = 8079810E3696173B9B146B30BECD6839 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */;
 			buildPhases = (
-				AFBBD00204B0DE1AF33E31790BAFB6AA /* Sources */,
-				BA5FB10DFA7BE2F62E3E80733A5AFC8F /* Frameworks */,
-				DFA22B378CD5F8F32E791DE18868FE0C /* Headers */,
+				8F614F11448FB8D24CAF92FC2EC310C9 /* Sources */,
+				5B9AD2B7B65DF14A762307A8A73EE875 /* Frameworks */,
+				51ED09E583E3F03FD0A3532445EBE210 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				850A1F879F3ECF905E1A1DBE68D59C45 /* PBXTargetDependency */,
+				DF6A2684AC0D16DA1B3430CB763C41B5 /* PBXTargetDependency */,
 			);
 			name = PVGTableViewProxy;
 			productName = PVGTableViewProxy;
-			productReference = 4CC3B178C094FA1530EDA46FE4E58777 /* libPVGTableViewProxy.a */;
+			productReference = 7463661F2733D7C3DB857381E05EA4A2 /* libPVGTableViewProxy.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		8B358078E7CFBD2C979B5063C6CC65E3 /* Pods-PVGTableViewProxyExample */ = {
@@ -1024,8 +1024,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				65576EE1DF42C594621F9C1103991CDE /* PBXTargetDependency */,
-				737B8F241434C020C8C91B4A4757AABB /* PBXTargetDependency */,
+				2B0D280020B431D9083D820E3FFEE7F8 /* PBXTargetDependency */,
+				D956864432C3A049D365C9C9B4CAA150 /* PBXTargetDependency */,
 			);
 			name = "Pods-PVGTableViewProxyExample";
 			productName = "Pods-PVGTableViewProxyExample";
@@ -1070,7 +1070,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				02E0E782B528F3966A5430E15671F8D0 /* PVGTableViewProxy */,
+				62231171C8B9A0C2DE60B9DAC7AACA79 /* PVGTableViewProxy */,
 				8B358078E7CFBD2C979B5063C6CC65E3 /* Pods-PVGTableViewProxyExample */,
 				D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */,
 			);
@@ -1184,42 +1184,42 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AFBBD00204B0DE1AF33E31790BAFB6AA /* Sources */ = {
+		8F614F11448FB8D24CAF92FC2EC310C9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03CF2EAA5EA36D96268B64842A008865 /* PVGGenericTableViewProxyAnimator.m in Sources */,
-				4BA1CA0D77F60F4BC58997D4948A49F4 /* PVGNoAnimationTableViewProxyAnimator.m in Sources */,
-				FBD3C27B3D55B650DAAA30837DE0BB56 /* PVGTableViewProxy-dummy.m in Sources */,
-				9719B488BE1B873F9F6D6B0B68CAAE4F /* PVGTableViewProxy.m in Sources */,
-				739507349342B8965D8449610A75B567 /* PVGTableViewRenderCommand.m in Sources */,
-				C4A8EA75D7E30C7846E36C142FA9D2EE /* PVGTableViewScrollCommand.m in Sources */,
-				F24B07965937DFD518280770243393AD /* PVGTableViewSection.m in Sources */,
-				73D0F0F197F014AD95E401C72CF277E7 /* PVGTableViewSectionHeaderViewModel.m in Sources */,
-				90F9287A329E123E49B3A233E0E991A9 /* PVGTableViewSimpleDataSource.m in Sources */,
+				98041E01773DEE7C937F218CC8727D31 /* PVGGenericTableViewProxyAnimator.m in Sources */,
+				867B622D86440B794736E20DDE01B6FC /* PVGNoAnimationTableViewProxyAnimator.m in Sources */,
+				1C5E94ED93BDEA60BC05BCF644E19CA4 /* PVGTableViewProxy-dummy.m in Sources */,
+				16B368967B1B25BF200A8A970A9A4CC4 /* PVGTableViewProxy.m in Sources */,
+				3DF24DB626E37A829D154AF751DB1ACD /* PVGTableViewRenderCommand.m in Sources */,
+				9C394BF05CF322754E4413DD54EDD168 /* PVGTableViewScrollCommand.m in Sources */,
+				B9F807F67402082E504D7E15CB540D78 /* PVGTableViewSection.m in Sources */,
+				93CAE6647E7031278C94D26E528FABB1 /* PVGTableViewSectionHeaderViewModel.m in Sources */,
+				9B85C6981A6C827AF64A660ADEA964EA /* PVGTableViewSimpleDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		65576EE1DF42C594621F9C1103991CDE /* PBXTargetDependency */ = {
+		2B0D280020B431D9083D820E3FFEE7F8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PVGTableViewProxy;
-			target = 02E0E782B528F3966A5430E15671F8D0 /* PVGTableViewProxy */;
-			targetProxy = 42D081440C4DB5E84321C3D688CB2E9D /* PBXContainerItemProxy */;
+			target = 62231171C8B9A0C2DE60B9DAC7AACA79 /* PVGTableViewProxy */;
+			targetProxy = E2AA3AEC9CEB29925765EC3BD9B5E50F /* PBXContainerItemProxy */;
 		};
-		737B8F241434C020C8C91B4A4757AABB /* PBXTargetDependency */ = {
+		D956864432C3A049D365C9C9B4CAA150 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ReactiveCocoa;
 			target = D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */;
-			targetProxy = 89B265FE05475A5ACD18487E635F4B72 /* PBXContainerItemProxy */;
+			targetProxy = 9140BBEBB7B3C15366B37509237A03C0 /* PBXContainerItemProxy */;
 		};
-		850A1F879F3ECF905E1A1DBE68D59C45 /* PBXTargetDependency */ = {
+		DF6A2684AC0D16DA1B3430CB763C41B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ReactiveCocoa;
 			target = D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */;
-			targetProxy = 4C232C6F85855182932E4AF15DB842C3 /* PBXContainerItemProxy */;
+			targetProxy = 914D098C142CF1841728630AA26FA6D3 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1297,6 +1297,22 @@
 			};
 			name = Debug;
 		};
+		5D285481B6F53092BA9C92F22620E84E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E0537CD933CE6FA2C39CCB63ED5AC82F /* PVGTableViewProxy-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
 		640E9116FD064CB3AE2B249CD334A1FB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2D6D9CB5B540BA150530CD80861D889 /* Pods-PVGTableViewProxyExample.debug.xcconfig */;
@@ -1307,22 +1323,6 @@
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		7948808E17077D2FD2001199F2BAD040 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 198F5B20B991C69949391F16658913E3 /* PVGTableViewProxy-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1345,6 +1345,22 @@
 			};
 			name = Release;
 		};
+		ACE22E914DCAD8F1353FE31A0BBC6A66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E0537CD933CE6FA2C39CCB63ED5AC82F /* PVGTableViewProxy-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		AE3A1E8F00BBA00F7AD36A3F5BF8720B /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E9D743CFCA3AE9B69424FAA2EA6626DD /* Pods-PVGTableViewProxyExample.release.xcconfig */;
@@ -1355,22 +1371,6 @@
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		DF10303C4ECCFC149E4BEA20463BD417 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 198F5B20B991C69949391F16658913E3 /* PVGTableViewProxy-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1414,20 +1414,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		8079810E3696173B9B146B30BECD6839 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D285481B6F53092BA9C92F22620E84E /* Debug */,
+				ACE22E914DCAD8F1353FE31A0BBC6A66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		AFFCFB82849880BE54E6AE3ACEDEB612 /* Build configuration list for PBXNativeTarget "Pods-PVGTableViewProxyExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				640E9116FD064CB3AE2B249CD334A1FB /* Debug */,
 				AE3A1E8F00BBA00F7AD36A3F5BF8720B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		C7E67073F1544797373B2C61B1F20837 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7948808E17077D2FD2001199F2BAD040 /* Debug */,
-				DF10303C4ECCFC149E4BEA20463BD417 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/PVGTableViewProxy.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/PVGTableViewProxy.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CF1F10985FE2AA13F23AAE5B"
+               BlueprintIdentifier = "A76942A329FA249F3B6FA0FC"
                BuildableName = "libPVGTableViewProxy.a"
                BlueprintName = "PVGTableViewProxy"
                ReferencedContainer = "container:Pods.xcodeproj">

--- a/PVGTableViewProxy/PVGTableViewProxy.m
+++ b/PVGTableViewProxy/PVGTableViewProxy.m
@@ -175,14 +175,16 @@ static BOOL enableDebugAssertions = NO;
     PVGTableViewSection *section = self.sections[sectionIndex];
     
     NSArray *lastData = section.loadedData;
-    section.loadedData = newData;
+    
+    section.loadedData = [self removeViewModelsWithDuplicateUniqueIDsFromArray:newData];
     
     id<PVGTableViewCellViewModel> firstViewModel = [section.loadedData firstObject];
     firstViewModel.sectionPosition = TableViewCellPositionFirst;
     
     id<PVGTableViewCellViewModel> lastViewModel = [section.loadedData lastObject];
     lastViewModel.sectionPosition = TableViewCellPositionLast;
-    
+
+
     NSArray *indexPathsToReloadWithNoAnimation = [self.animator animateWithTableView:self.tableView
                                                                         sectionIndex:sectionIndex
                                                                             lastData:lastData
@@ -561,11 +563,31 @@ static BOOL enableDebugAssertions = NO;
     }
 }
 
-#pragma mark - Helper
+#pragma mark - Helpers
 
 - (UITableViewCell<PVGTableViewCell> *)templateCellForReuseIdentifier:(NSString *)reuseIdentifier;
 {
     return self.templateCells[reuseIdentifier];
+}
+
+- (NSArray *)removeViewModelsWithDuplicateUniqueIDsFromArray:(NSArray *)newData
+{
+    NSMutableArray *array = [NSMutableArray array];
+    
+    NSMutableSet *addedIds = [NSMutableSet set];
+    
+    for (id<PVGTableViewCellViewModel> viewModel in newData)
+    {
+        NSString *uniqueID = [viewModel uniqueID];
+        
+        if ([addedIds containsObject:uniqueID] == NO)
+        {
+            [array addObject:viewModel];
+            [addedIds addObject:uniqueID];
+        }
+    }
+    
+    return array;
 }
 
 - (void)dealloc

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - OCMock (3.2)
-  - PVGTableViewProxy (0.1):
+  - PVGTableViewProxy (0.2.1):
     - ReactiveCocoa (= 2.4.2)
   - ReactiveCocoa (2.4.2):
     - ReactiveCocoa/UI (= 2.4.2)
@@ -17,11 +17,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   PVGTableViewProxy:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
-  PVGTableViewProxy: 338a83dc91a77cee0f2bac96d084f755f66a7957
+  PVGTableViewProxy: f2cd021da863b3c1ea193541c81772bc94356506
   ReactiveCocoa: fdf629a7321cc7504936fa86243d8c616faad302
 
 COCOAPODS: 0.38.2

--- a/Tests/Pods/Local Podspecs/PVGTableViewProxy.podspec.json
+++ b/Tests/Pods/Local Podspecs/PVGTableViewProxy.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "PVGTableViewProxy",
-  "version": "0.1",
+  "version": "0.2.1",
   "summary": "A React inspired component to be able to declaratively use UITableView.",
   "homepage": "https://github.com/plain-vanilla-games/PVGTableViewProxy",
   "license": "MIT",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/plain-vanilla-games/PVGTableViewProxy.git",
-    "tag": "0.1"
+    "tag": "0.2.1"
   },
   "platforms": {
     "ios": "7.0"

--- a/Tests/Pods/Manifest.lock
+++ b/Tests/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
   - OCMock (3.2)
-  - PVGTableViewProxy (0.1):
+  - PVGTableViewProxy (0.2.1):
     - ReactiveCocoa (= 2.4.2)
   - ReactiveCocoa (2.4.2):
     - ReactiveCocoa/UI (= 2.4.2)
@@ -17,11 +17,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   PVGTableViewProxy:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
-  PVGTableViewProxy: 338a83dc91a77cee0f2bac96d084f755f66a7957
+  PVGTableViewProxy: f2cd021da863b3c1ea193541c81772bc94356506
   ReactiveCocoa: fdf629a7321cc7504936fa86243d8c616faad302
 
 COCOAPODS: 0.38.2

--- a/Tests/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Tests/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,201 +9,210 @@
 /* Begin PBXBuildFile section */
 		004195958E6D4630121D110149BDF107 /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = FBECF5ECA4DFEDFB2FB49F3FA8B676D2 /* NSURLConnection+RACSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		03011BFD1500A28A767DCE9C352BC7B4 /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 40D1DAB6CDF14063CC2EAD478C794D60 /* RACIndexSetSequence.h */; };
-		033491472A99EAF93018C8547804624A /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9986C9CE4CE4D4D9FEA23F793ACECCE2 /* OCObserverMockObject.h */; };
 		03AA6DC79A17CE2C4A452320939B72FC /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = DE678BD13584DC6861FEDAE08F442AD5 /* RACQueueScheduler+Subclass.h */; };
-		045430349CD69DCBE76D80768670DCFB /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = ACC64AC47544271C1623B23901E41970 /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		04777763BA6EA4DAD9E28772AA89BF22 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F0453817FB9F7376D8CB00546A335268 /* OCPartialMockObject.h */; };
 		0487A2719875D143CEF84C97C495BAC7 /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 19B450BDFA71F70143195DA2092E8F6F /* NSFileHandle+RACSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		048E02FD0AA95AA8A30A28F7877CB51B /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A69226374214E7F69EAD30964973489 /* RACMulticastConnection.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		067A167866956FD155017B6C0D352D08 /* UISegmentedControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DA2747950788C668FEB126121009655 /* UISegmentedControl+RACSignalSupport.h */; };
 		07F926B14EA9709E73A0FD31DC1E91E4 /* UIControl+RACSignalSupportPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EA7F48F074150BCC0456D45734DD775C /* UIControl+RACSignalSupportPrivate.h */; };
 		0895575754ED8B4BE2023A5C98A8ADB5 /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = A598DC9557D3DEF6E8FAEDF22AC94CB3 /* RACKVOChannel.h */; };
-		08DE9EFDE4D1721F7660DF1F3E7CDE59 /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F315B7ECB8DBE8AA0997267C1893CF7 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		08E9225BDD4E6A9E759F2A45B119DA16 /* OCMock-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 47B7272403ACA6E3D6558E4A7BE31D17 /* OCMock-dummy.m */; };
+		08CF41BEB018D1F30D39B5EB10DBFC88 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 26EB63963AB04C503AA348BA83CC02A0 /* OCMInvocationExpectation.h */; };
+		096C88AA5B79B6C58E92864923CC2C2A /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 80FE5B4C23977BE305C2DE60E73DFE49 /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0AF94951F8F49A9A121FE89ECB78CA7C /* PVGTableViewSectionHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 99EAF7C66E7FE027E623E75049423CCB /* PVGTableViewSectionHeader.h */; };
 		0BC890CCDC7980DBF40E048662C325E1 /* UISlider+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E52DFB8D644239658D299590B6B65E12 /* UISlider+RACSignalSupport.h */; };
 		0BE3092432D63B258EE8F2C6D3EA44A4 /* UIActionSheet+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 8698798B5EDB069C55026FDAD48DD9FD /* UIActionSheet+RACSignalSupport.h */; };
 		0C3EB6550B851852264030B1BBD78613 /* Pods-ios-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F56B8A7DF844C30E726C00CDAF2CF109 /* Pods-ios-dummy.m */; };
 		0DE90D9600E1A809D61E766CA14929FE /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 91B9728F6C900C2D1BF1953CD65AFD9F /* RACUnarySequence.h */; };
-		0EC22281B28D68450280E577BDD63685 /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D2C33F9E87044784262347F653AB066 /* OCMExpectationRecorder.h */; };
+		0ECE4D58CC0EFD1C1446E887B769A26F /* PVGTableViewProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = F73AC6A44543CA993B9EA8250376F4D5 /* PVGTableViewProxy.h */; };
 		0EFF0B1E761D49D41143C4C6F7F6854B /* UITextField+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CF46039EA83E404B60E87DF501BBB1 /* UITextField+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		0F65CF489C1062D5DFD55397D0BF78AA /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C920DF194B4B54D98AB9131ABA53F72 /* RACValueTransformer.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		109A2B919901024FBD1818709B70321E /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = C9D2E1DCBC47262917BEC8D90EBC5403 /* NSObject+RACLifting.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		10DB0173EAC05EE5DA0D3F5BA992F009 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 42FD7E848AABCAF8C97EF727DD712BD7 /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		10BFB7976429D7FE1CF9547B0F347E00 /* PVGTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = BD73C23F7F6D4BE34DA89723C67DC7C3 /* PVGTableViewCell.h */; };
+		12167D3E958C487FAF4DFCEB68CDA979 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = AA99F0852C84DE380258D68DC5BCBE63 /* OCMPassByRefSetter.h */; };
+		121A806FFD0344CC4BC753D70E9D6242 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = C6E0802894C26EAB6F0493A7A148697E /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		12F4D415007B72B84308862693775BB5 /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 50CD25838196EF77602DC8A2D9AB669F /* NSObject+RACSelectorSignal.h */; };
 		12FCB1C63DF382A03BCD262D8146AAEF /* UITextView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = FD795880489EECB79036A42CA7491636 /* UITextView+RACSignalSupport.h */; };
-		1349708AD35911009C7C7866BD5DA176 /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = 82944A7CA6E952E30D9EEE98CBD38DC5 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		13606C2F2D5E0572F8B7616C821B65A1 /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D65F669BBA9FD3472182008FD2F56F1 /* OCProtocolMockObject.h */; };
 		13E32B3905601FB38D239D8E70D8F450 /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0313CA92A67C11509BC7D9B90344D6B7 /* NSURLConnection+RACSupport.h */; };
 		14A7A5B23481C74D8E773E82CB3F2022 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 91A70A055D199DA59B7AA72048BC6495 /* ReactiveCocoa.h */; };
 		14F5457BB2550BABDA95920E30E04065 /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E5167B723330C59160193234EB2202E /* RACBlockTrampoline.h */; };
 		151BA60747C60C27F2FCF101362C105A /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AEF1A37504F52691DAA2195D8901F8D4 /* NSOrderedSet+RACSequenceAdditions.h */; };
 		154E2EEBB7BAB9AF3F139B70B8D2198C /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 16DCE8BE4EDE00588F338BC951937A99 /* RACErrorSignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		15A5F637AA6278FFD472125CEA31FF64 /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 645C0AF40ACADF2D65ED38896502C3D8 /* RACSignal.h */; };
-		175DDDBE53D332CDF19FC7B07EE454F4 /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 49F83A0E46824B501A3B42347E730DDF /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		163CBB06079ACB78C13BD6EADBDEA549 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = DE89B09BA8C30A80D8B542B608E1891E /* OCMock.h */; };
+		175F6329587AF94B1B166F391D557FE7 /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = FD9419A0B9044AA266828FE0B621E8D0 /* OCMExpectationRecorder.h */; };
 		1870C9910D9D17DA500849A36566D9A1 /* UIRefreshControl+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F28C851A91A9877DB8589C7770E48B37 /* UIRefreshControl+RACCommandSupport.h */; };
 		188DB40F47F21EF196FFE52E286D5CD9 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = AD51D875EFE9D59C4C349E11359CA076 /* RACMulticastConnection.h */; };
 		18BC4E5F7C089095D7C9459AC524C0EE /* UIControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 62C4D4C72D34B1C31A681E14150D5C35 /* UIControl+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		191FC840B439C66D6B923D06CDB2CDB4 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6482D6D6A0A79192D2195C2C8436590C /* OCMInvocationMatcher.h */; };
-		1ADE37165A48253AF9381C1FE2F6C983 /* PVGTableViewCellViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = C8528A5A5D415665F6671E7054AA5E94 /* PVGTableViewCellViewModel.h */; };
+		1970015CBE9B518ECB589B723C357FD0 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = E4B2263AD42ADB1CF8E843462E69AA7C /* OCMMacroState.h */; };
+		1B4B0BCF62D40AC14C16F750E8A93D9D /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F0610842A13AFB6055709F664887F45 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		1B68CDE2DF4F483995C1A0AB75D1996E /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 731CB8BBB296456F60B763EC89FD783D /* RACValueTransformer.h */; };
-		1BC7C9D26650802A909E6EF8515FF6C5 /* PVGTableViewScrollCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C5228A268F4112752FE411237D0244A /* PVGTableViewScrollCommand.h */; };
-		1C10C4029DB6812B1A460F8B79279BE1 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = EF0584A05212CB32368B2EC16951890D /* OCClassMockObject.h */; };
-		1F8BF4C2F5A89E5E3AC7C65277C38F2D /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = D1CDC7E4CB9807F50B7C17CEFDE60A91 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		200106845861E197C8593BFCDCA48961 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 9841F05844C39EE6A0DAA2C7657A95B2 /* OCMRealObjectForwarder.h */; };
+		1D30E3D7A0A454ADD17A6EBD298FAF01 /* PVGTableViewScrollCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE12809B21B09380C7106A8C88C00BD /* PVGTableViewScrollCommand.h */; };
+		1E82318C960EA186382BBC8BB2C0266F /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E2C11A90E0D113667C3744FDF8BDAC70 /* NSNotificationCenter+OCMAdditions.h */; };
 		2093A312BFA3CA886D8F6A75537A8A22 /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = E8BDBE95107A32FC97E09AB9B81D4867 /* RACCommand.h */; };
-		22959BF5C2F33FB5A0ABA239E3FBFE91 /* PVGTableViewScrollCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = F7783DDB52C7D34D61CBE52B2782B867 /* PVGTableViewScrollCommand.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		22D04FC586D6001B4971798DE53B6125 /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 58C91BFC78E6400DB7A70EC0B4835702 /* OCMArgAction.h */; };
+		2289D7DE08C240F4D2AB52F96966C1EA /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = A4D30D704C888A908D6F290E3ED41C9F /* OCMConstraint.h */; };
+		23F1890731EDF45E1F1971337E0EBBDB /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 95F8544BAAE540790C398B5433590EAD /* OCMFunctionsPrivate.h */; };
 		241970783CB71FCA2AACEACD772CF225 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B4C933FECE1CDE00719BAD43AFB2287 /* NSObject+RACPropertySubscribing.h */; };
-		242AEF7303BAE66D84C57C731D946787 /* PVGTableViewSection.m in Sources */ = {isa = PBXBuildFile; fileRef = B6925CFB0BE92594EB794223DF2554B4 /* PVGTableViewSection.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2598C8252104462029D576EA330A520F /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = 60CB68286AA49CB73A80B4FD04A9F281 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		26C6368B41ED48224C70567BA92D860F /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = ACAC49417FE432461825E75CE151D4BD /* OCMVerifier.h */; };
 		2741DAAC41282E4320A27976D81F1E2A /* UISwitch+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A8CC4405DC933D32370924D2AAFCB295 /* UISwitch+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		28CD7B74D5E4EBDAA8848D92406D0249 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 9709C1909E720888C6FC913104CFBADB /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2A4DCD6C637F48CE69FFBD9C9A865C2C /* PVGGenericTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = A90257329F94219C7AB6A66A347CAFD7 /* PVGGenericTableViewProxyAnimator.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2976825D67AB6716D1AE54BB8CCB833F /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = C12944A489CCADD0DA3DEE596FE1B846 /* OCMInvocationStub.h */; };
 		2AB100CE3E04ECB54CDA15AB6C683147 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B84CB9F23C2898D165E3CC7B366710A1 /* UIBarButtonItem+RACCommandSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2AD31A1B15426DDEA8EC49B0ABC44DF9 /* UIActionSheet+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BAB85A2CC1046842ACE5B1749380D9A /* UIActionSheet+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2ADC6E977FA84382273DB58779B743C0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
 		2B4E6C7105C0AF22B4C2F99D2D37EA5F /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 922CAF6D4FCADB193A65F5421B238F8C /* RACArraySequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2BAC364EFEE11D01D2F758D58612FEA8 /* UIDatePicker+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D64AFC4855D4951AF20E2A15CF6B42C /* UIDatePicker+RACSignalSupport.h */; };
 		2BF721F3B6409DC62DD9FE753884AF60 /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F23D47FC49F17706B3704B858F641474 /* RACDynamicSignal.h */; };
+		2C1A0AEEB1491455D0F8B335097BB5C4 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = EEA20DACB12809F7B9D73DC0CFB4C8AB /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2C586A73B146D868563D026AD18E20F5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
+		2DAC60F7A5CDE44A296357C599775350 /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A167B84312F3EE1F413DE70F203D3A2 /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2DEE06A34450E633A99B45655E3401F9 /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECE3636B2F44E26A268736AE7D1B8F2 /* RACScheduler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2E6AF8C0E5FCCEF9BB933661FF38D582 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B7EE9DA39CC3F39FC50556E9194144FF /* OCMIndirectReturnValueProvider.h */; };
 		2F32074B19910E80757DAB385C5B6273 /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = C7AD4041B478EC9005BF39A02B58A4E3 /* RACSubscriptionScheduler.h */; };
 		2F48FB1CB51096D571D222C6B8802BF8 /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 922263689244BB247089E56E21317FF1 /* RACSubject.h */; };
+		2FC379687B39959B83EA9957E0216DA6 /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D89D360A67C35D7C01465F95D4BF29D /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2FDE01E178D81D8D98DB42F436ABBB44 /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D53C270F9F3DC9CB1A5B01CE6A9FE6E6 /* UIGestureRecognizer+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3029DBE6BDD20D3BEEFDD9B4DE57B35C /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 82EF5CAD58DF6BD48DFAC5FF9D19742D /* RACDisposable.h */; };
-		30501E4C88F541CF0E2031201CB50F67 /* PVGTableViewSimpleDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A34D070036E1B8F41CA70BA8BCBFD22 /* PVGTableViewSimpleDataSource.h */; };
+		31109AD6A330A8BBD6E702FFBA3F1D50 /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 86A3FAEABDCAA30D2992029959D2DCC7 /* OCMReturnValueProvider.h */; };
 		3372EB05F45D33D99513144BBDC03463 /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 6220A21BE212F9D6DC8430F945174A8B /* RACDisposable.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		34C2164FDAF19BCBC725B13ABA77311C /* UIDatePicker+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 50573FB164780E69532A8E40FE14D9F6 /* UIDatePicker+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		35E595B682D087E9F52E21C8187A33FA /* UIImagePickerController+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A2F6659A2DCFC1A1AEFDF257CF81F07 /* UIImagePickerController+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		360973D2CF7133E6674C913F186A0D76 /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 00368C2B27F8B758D3EE22FBEA8E3298 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3614656F7B4CA8630B66366932138D4D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
 		36975BF5E83D79289DDEA415E8EE03AE /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 259A96310123EEBAE08CD792E8B04F1B /* NSSet+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		36EC8C1C67719A62A0476F1B296C56B0 /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = 920D7A59A7DAE570F8DAC361EE3B4E7A /* NSObject+RACPropertySubscribing.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		37C67244DA139093DCB27A8C081E08B1 /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D95B7E1C217581D6C85FE670C44C75B /* OCMReturnValueProvider.h */; };
+		3755EF45DFBF563B4CA1BA8B3B4ECC36 /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 00759EFCBBF0E79AD01414A9B9EC4EF6 /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		37F4694F89D7E7E6089CCE2E08AA562E /* PVGTableViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA29883DC280E4C31FB87A9B1A09EF1 /* PVGTableViewProxy.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		382304013F4FF6B346F5AD9948E9A152 /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A850C4B949F8C3B3274B2BDC3B699B9 /* RACQueueScheduler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		39C7A808A4DE2F42DE3B068D01B56A8E /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = BE6D87FEFBE34D9E57ACB2CFDF3284A3 /* RACSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3B8552735E004A2708C6EBF13F85B8C8 /* UITableViewCell+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2640B557DCB791022E6C94DF90931DA6 /* UITableViewCell+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3C5AF4C91BEEE9E96F93237F54141ADA /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 06B2C4C53B4320316B5F030A895E7BF3 /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3CABCF061ED07E1185CE425D349D453C /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 342812A379B74454B8C6795EF46E1C5A /* RACStringSequence.h */; };
 		3CD3052927509A8DC5093E2DC93DDCAE /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AB0F51FEC409855C488EF1E6DD4121E7 /* NSSet+RACSequenceAdditions.h */; };
 		3D8A593B0520898CF86144B723497807 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BEA2C4A89DF586C1C4B77E2E18587A1 /* RACSignal+Operations.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3EEA542EC7FA1A065D97EF71AA792F4C /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 771971D9207A05ACF42A8AD2E5A83E5F /* RACSubscriptingAssignmentTrampoline.h */; };
 		3EFA5EFC34C4E999AA7CB3CBCA848068 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC2DB1E35FC7686645F432E2D43EED6 /* RACSignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3F8FEE411AE0A00240DCE05A25B5A419 /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 21EA8575483C4E7C762146F6B054CE29 /* NSObject+RACDescription.h */; };
-		406AE0AFC913250B2DE2A972ED596DAE /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E139E2CBB9802966FF9945BB90A8E0A7 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		40AD1EB9CC4F21C6914A9E7DE70DB1D9 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B69520299977F607F84A81182091D9A /* NSIndexSet+RACSequenceAdditions.h */; };
-		4146DBDB1C52DD19E299B56460D4B053 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = EF330328B5D7D7AC14B3BCCDCEA0F8E8 /* NSValue+OCMAdditions.h */; };
+		425F701EFFB6204C3E7B3D24CD22DCA0 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 345967331A372F93EFA1890814C86068 /* OCMBoxedReturnValueProvider.h */; };
+		43303FA0E16C4B661CA9CF1D74BA6DFB /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B06CD0B34F6DF74A3006A46BD99B58BF /* NSInvocation+OCMAdditions.h */; };
 		442995409ED06993C67CDC55CC2A75D9 /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 37D709F35746AA6116789A7E67C58856 /* RACArraySequence.h */; };
+		449FCD185192C1FEDEB84AAA0D876F16 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F266271867DBDB9D204D0D625A94000D /* OCMockObject.h */; };
 		458EAA902ACB9EF68C4D9AB1148DEDDC /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = AA64D794ABE0DBEF7C33B192C7A8A923 /* RACReplaySubject.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		46AB978AE383D66475D7926A7689E4BA /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A87B9EC03DCFBBE45E9A3DF6EE144 /* NSInvocation+RACTypeParsing.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4943516AD811FE9E08C0F6CA611F1B9D /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D3194E20C34D7BB582FCC9713922A4 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		487F68EC0D6128F1325746E691757270 /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 16570164A52BE2E3DD5CB6572A35573F /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		49536E70852C285B83CA5D2ED9660CF6 /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ABFA4091A89C6B20591C4E668D4A84C /* NSUserDefaults+RACSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4971F6B107B84072291DEE6FAD93C010 /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = C55DDA26080B8843460C52F1BA04701C /* RACBehaviorSubject.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4A212AB0D0E5385C1748633AB935DADC /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 14C127A7DF26F806FB0A86D715D3F76C /* RACEmptySequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4A5FF75193BA1BB08EC3D7082E08E33A /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 49DFABFDE2144F35EC2E3064DAD62BB7 /* NSString+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4B3F42338DABA69A3C11BEE64A8EE191 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = E556193E2AFDAC07ACCD2F548A36A278 /* OCMBlockCaller.h */; };
 		4B53B998A3D31B0C322911114B7B4C00 /* UIStepper+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = ADFFA519A388AEA9CCB9063946D66E43 /* UIStepper+RACSignalSupport.h */; };
 		4C439E761AF867E12AFE6B01E59C0B29 /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F6E2259805A58291730DE532888E5F /* RACEmptySequence.h */; };
+		4D1DD611F216B0159E1DE747C6D8AF0D /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4EE0C6D45024778A4070BE5B352D51 /* OCMObserverRecorder.h */; };
 		4F2E2201A5A62A8AB0F726556ED671F4 /* UICollectionReusableView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C3310059DFDF761BE07487D9CE4F041 /* UICollectionReusableView+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4F8B1BECC036961C0ECD1D72FD6EE4FD /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA38B00DA2B8C6F7E504DC1760993A8 /* RACStream.h */; };
 		50AD18294B9D4A668089532062F3C8B4 /* UIAlertView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = F6589A44A1689815B788906281BD2858 /* UIAlertView+RACSignalSupport.h */; };
 		512F4C1797D2D7A6388F961E6D44EBBA /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = DA324113BB8AB2C2F3051396AA5A388C /* RACEmptySignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		51FF967C81A8B732A72DA585E1ADEFA0 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = DC6EA08A346B8970E9699719604B50C8 /* RACSubscriber.h */; };
+		5247A1E231F23050B8EF4D005937D700 /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = E6493A202079E04EA706393D78424CD5 /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		52AA920697B8280E255E23F53D8A9619 /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = C97EFC6BB3F7B44668F64A38E130E992 /* NSObject+RACLifting.h */; };
 		52CAF5C6D36F2B7B32629373AB6E4687 /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A7E545F8BA80D2A6652305B16FFB89A /* RACPassthroughSubscriber.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		52EE0FD2DF4325A5D47249E4EBE6C17A /* PVGTableViewSectionHeaderViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C8C7366D1C9E2044EC9EAAA51DF743D /* PVGTableViewSectionHeaderViewModel.h */; };
+		52EE6A5ED20ACEA8AC7FCB1DC2D67EA5 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D27096DDEEDC45EA2F21232B4D3A8EC /* OCMStubRecorder.h */; };
 		5302EBB5DF5EA43FCFFEB6E3EA745E58 /* UISlider+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A3C1D9D5D867A955FA26D85403C665F /* UISlider+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		53E4D7A4CB10CE8E1F26AC5777A63E25 /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF67FEE641CFEF0BE5DCED6535DD8AF /* RACSubject.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		53F0E9B7D3D09E1FF2A4E539D464EEBD /* RACmetamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CEDE813274E5575E4CE20ECBF73370E /* RACmetamacros.h */; };
 		53FA4C6198E0F5D8B10D0C55E1AAC46F /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = EAE4BB5D11B18A86958894270F4357C8 /* RACEagerSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		54F59785AC3ECD3DCEAA98710F510F69 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 67525045ED955F40E7199959340A76D5 /* NSObject+RACDescription.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		55DAA752E6A1EACF9B03F9191F970E4C /* PVGTableViewSimpleDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A5248683C4E55F6204D49CC45449AD /* PVGTableViewSimpleDataSource.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		593F21399A82840D9D708BD5982B3708 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 69A2B75A66C6D250737F21FE802C8337 /* RACSignal+Operations.h */; };
-		59786D5ABD8B842575EFB9C6C7AE0009 /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37680914889200B2B9050743215DBBCB /* OCMFunctions.h */; };
 		5A63CFF97EEA60D4B8681FC371BA5CAF /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = B9B383D316786CD1F391BDAF26040D91 /* NSObject+RACDeallocating.h */; };
-		5A7F4111FDE893DB25BDBEBB2A25263F /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E997CA2B005D958F4D7DEAC7601E626 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5AD1722490CD393DB93DFA9DBCCFB5DA /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 64BF94CD950860CCC454E35CAFD22649 /* OCMExceptionReturnValueProvider.h */; };
+		5AE25C0EFE636068F51A96D2BA19BD27 /* PVGTableViewSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 90EEFE38D42D289FEF46D7C0F1204E20 /* PVGTableViewSection.h */; };
 		5BEE584E7CC58BFCB8E8AFD841ADD371 /* RACEXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE629FEFD8701CFC7E220B7E4F51EC2 /* RACEXTScope.h */; };
 		5C790507FA38AAD55705CCA2F5C6EC9D /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = C59D6FB68DDFB619171281D2757B6300 /* RACObjCRuntime.h */; };
-		5E8230DEC6B6D73F84C2B956555E9BDF /* PVGNoAnimationTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = B2FF6B6E10B1D2C3A96DE6AD4CF793B2 /* PVGNoAnimationTableViewProxyAnimator.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		60D41D18CE947ABD68A9045084D144D6 /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F262D391B5F1EECE3493A5FB99E23DEC /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5CF9424606613D1BED57E588D5DCAACE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
+		5DF1B32F5D2F818DDDEB20BBF566FCA8 /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B16A3715B92A9996BD1FA3A83CC62291 /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		613D2888855EDA4CC04709B7E2A98382 /* UICollectionReusableView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7739114363484F5B99FC942CA441E734 /* UICollectionReusableView+RACSignalSupport.h */; };
 		6493534EFC862B2DE7677283B07C0EE3 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 71060F211137E401843C82AFA05CE091 /* RACSerialDisposable.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		65A8C260690014E7CB47BADA931BCFE5 /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A7456E91F97A5382D9F631815E4B39CA /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		653CB12B2C3C95DEFAB58CCB9B636C46 /* PVGTableViewRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 00779B7557C38374810DC1E9A2585C4C /* PVGTableViewRenderCommand.h */; };
 		665AB67AF73FE89F4C3E60A38DF0FA55 /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 430B51A6F3628BC3B45B84F3D857CC87 /* NSObject+RACKVOWrapper.h */; };
-		665D6D5C55F7E8C1E32B5A1485237FF1 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D6972A1269B6913FDD3FFCD0B7CD38A /* OCMock.h */; };
 		6754F08EF198326233351A4FFF6CC714 /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C8770B93A7AAC90292717828E109773D /* RACStream+Private.h */; };
 		67E9A5CFC175F935A3B3035C2A2B1A8D /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = CA816BF237380D6C013E347D3A95E25F /* RACKVOTrampoline.h */; };
-		68E07311952A0369BE758F81D9EF2179 /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 46D48BDC8A8AB37DCD86A40A66E88ED3 /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		695783CBF9EB0D4819EEDD8EDB1FFA96 /* UISwitch+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D7D3076151A27E89C1B7411F17D0A044 /* UISwitch+RACSignalSupport.h */; };
+		6A10FBA8E2619C433C6BBA1CB85CCB3F /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A6541559C7DADE343D7A70D973391A /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6B587A49A9F7F966CA21A5EF3E3A4620 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 3692CADEBCEE54F58CFBCA9C0D49764B /* RACUnarySequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6BB44741DBD832EC4D2D0EDCC5FC6CEE /* RACEXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 78160B2DAB1F0CB79B67FAE296B0A316 /* RACEXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6C44A390631152F5F8BFDE26AAC057A3 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = D4822B4DFF40D3E9D959CCBFA9D23102 /* OCMRealObjectForwarder.h */; };
 		6CE1978D7465AE5DF4DBB253D22A7AFD /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 815FA3941258787930F9C93FEECE1C70 /* RACTargetQueueScheduler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6E78E75465C6293C7CE4DE94A9F2C4A5 /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = E7F354EAD8C9B85C2CFF7DFFAE2F0E3D /* OCMArg.h */; };
 		6F25CAFA83E8910F78C06901678127AA /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EFAFB57EE6CA3C122D820FA12685EB9 /* RACEagerSequence.h */; };
+		70A7B1DAFA4427EB69A7D08B3F729F83 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D7FD8FA1E348598C720747E570634A6 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		73E7226A976AE52C535A9BCA27BBF142 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = D0287E25CF8AA4447711D1585B5AD7F4 /* RACSubscriber.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		750B0AB5396B94F10D8B020993A8111B /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1262D6ACE7E257C1CCF4C830B282F1A3 /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7414994301A906E1880330724A8DFA86 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = F96FDA238E756CC92965396035488E99 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		754F624E0D0FBF189A69F6799DCC24D4 /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 323F3AC4553E14CBF18E3BD1879BDE94 /* RACTupleSequence.h */; };
-		761EFAA064C113141AB9D0283F80C0CC /* PVGTableViewSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 3023AC99DF52D11654C7AEBCB8EB6BD4 /* PVGTableViewSection.h */; };
-		7792DE91DA902F175C30A80AA39F18F4 /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 556FD396E58E585893DFCDDFCE252104 /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		77B032755D8BBA6C2FE10E6DE25C1923 /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = AAA4D44A335DC832947DC0C39CDEE53E /* RACCommand.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		78666214B218EE47A6E381F4DB4CD3DD /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = FAE5389A3D9012ECE4F4433B88D4FAB8 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		78E92D6492C69E5FEB48A74FCBCCD75D /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B32918FD0D459981A25930AD07F6B52 /* OCMFunctions.h */; };
 		7910F8BC58A75910DBF816B262E3447D /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA00593500EBEDF8EA741B304A2E1F6 /* NSData+RACSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		793EC051289C5B7F11A6540969D9E710 /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4ED2D85CEBC801B17B542A20C4586B6B /* NSData+RACSupport.h */; };
-		7B02A58B25827D0A2F5369BC5E32A455 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A930AEF69CE9D9B6F367C60D73D68147 /* OCMFunctionsPrivate.h */; };
-		7BF72B890477CCB191A67FC1946FA5D8 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DA56DE4A59BA51C3F55249BD971FA34 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7D0BDA951CE5660800EE1F5A9460D392 /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = A98E938E27C44F08AFAB6FD2E7728AFD /* OCMArg.h */; };
 		7D2C5161E2A6D70C33C026A108B890E7 /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = 2118D3D33407B762E104CA8CAA844993 /* RACCompoundDisposableProvider.d */; };
 		7DBBF4A0E4D2CD2AA156A385556CE56C /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B8CFC154A95428B7ED73537D260054 /* NSString+RACSupport.h */; };
 		7DBDB431EF13942D77C5A19F06873003 /* UIRefreshControl+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 7675D758BEA43B616C22A12872243A2F /* UIRefreshControl+RACCommandSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7EFB3333EFE9EF38EF83D99F445CFFCB /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = 493A4CF157B8BD3271E6C3B7F19810D2 /* NSObject+RACDeallocating.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7F443CC5A462EF1B13062EA3130C6949 /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5465C01CB9D4D3ECB7AE33E1DF2B8BC5 /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7F51DA91D7CD1E2ABD0598B70E0AFB73 /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FF2B4C40E6B53880C8E24B78B0F7832 /* RACBehaviorSubject.h */; };
 		7F8DDFF438F9AACF382487F8A38B54E5 /* UIControl+RACSignalSupportPrivate.m in Sources */ = {isa = PBXBuildFile; fileRef = 867CB838C815185BD99E6EACB29C66F2 /* UIControl+RACSignalSupportPrivate.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7FE1B6A2485DDCFE7E8C71DA8874E55F /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 2299EEA967B0DD3636A96411075A2D00 /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		81096AC1AD61C0D3D81EE335B504E03A /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = B42C5004D70ABC119E7E26F283CC4BDF /* RACImmediateScheduler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		812EADFBFFF7E9597FAE47E280B954F6 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = 863F844B16AFBDC1B27A5F5CCA809D03 /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		81D62A3651B389463793439339C6EBA0 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B00CD4796DC365642F1FD6FD66D1C72 /* NSNotificationCenter+RACSupport.h */; };
-		82213D7AAB77109EFE59A3851BDCE6F8 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FADAACFC4CB488D7021A0E795B11177 /* OCMPassByRefSetter.h */; };
+		82035AD6BC75984F1FC671F43DCE693E /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 675566099AC1EE982389D39471AD4F64 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		82506B45C349A967FE62753BCC49C029 /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = C9DE51EDE54C035E8ED69E1D35F5D407 /* RACDynamicSignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8268F3D8F7DB695E29345321A6C76372 /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F942752256CBB49E0E90309B9E68FDD4 /* RACReturnSignal.h */; };
+		8372D00F71C8289F5BC0EFA3BC4E2ED9 /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F832602DA9932B51DF3EB2A38987A4E9 /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8376BA13C74C781A4BF0618BE199D66B /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = D028AEDED27B523D16538329374F085C /* OCProtocolMockObject.h */; };
 		838A8A79433CD43DFA671D6C63C0DD5D /* UISegmentedControl+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B7F8AF67FBB1765318FF2D3D17B66CDA /* UISegmentedControl+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		83D2C60A9575117D0EC436325E5E3C97 /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 95875C0920F9EC19B8FA7F5A96FA23EE /* RACSignalSequence.h */; };
 		846DF3B4ADA557334C1601F188D0FFC5 /* UIControl+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = BA97C73028E4F2C19682DC3F5D1F03CA /* UIControl+RACSignalSupport.h */; };
 		84D878F725843E3F33F5AD72176A6882 /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 79AB581354056E317CBCE93A9C1291AD /* RACSubscriber+Private.h */; };
 		850E9B89EC01FCDADBFDE97E55737240 /* UIGestureRecognizer+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = C5B8D17F7061AEB62F9F624A83C4C7F9 /* UIGestureRecognizer+RACSignalSupport.h */; };
+		85AC2EB9B365C77490E734209856E3D0 /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 68AA6F48A142721EEF090414F4337756 /* OCObserverMockObject.h */; };
 		85E973FB60A07A9E6F5253B35F6851D4 /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CE54CE749F5963EC960FCA05DCA6CCA1 /* NSDictionary+RACSequenceAdditions.h */; };
 		85EADBE7CD111315386E7F1EB69F1C4F /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = ABD3560945B4BCAA3867D74010DA1002 /* RACGroupedSignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		88E54DAB4929F93E93B931797E534A48 /* RACEXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF8F5CC10D35B3E8FDAD293BFDAE207 /* RACEXTRuntimeExtensions.h */; };
 		88E9DEEB28360B932BB7D91E5F31C293 /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A306134FA1B70D83AC83C8A45D54287 /* NSString+RACKeyPathUtilities.h */; };
-		89325843727E6895B657CC7990691122 /* PVGTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 33DEA5BA89EAF43034EC22A9F95F179B /* PVGTableViewDataSource.h */; };
 		8A44600A9C335C4C2DF8F8E1512EA02D /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 50CCFF25C487E8C2A2C4305939BD58D9 /* RACScheduler+Private.h */; };
-		8AF64E66191140A9338FF4162A2E58FE /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CD5EFEFAED8BF72C808A31C396D98A2A /* NSMethodSignature+OCMAdditions.h */; };
+		8A8968FBBB8979EE56713737B842D212 /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B8B3E93C84A55ACC3C313B6F3412A85 /* OCMNotificationPoster.h */; };
 		8B2797C3A800C089EA0C7AAFFED630B4 /* UITableViewCell+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 02785933B4E28BB3A0F7EB65005B6543 /* UITableViewCell+RACSignalSupport.h */; };
-		8BA999615D0AA2A86F7A88CF3E7BAB06 /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 318C4F9E950AAE22319EFA25180621FD /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8C426EDF32D36E1E94C14F1F03C4A767 /* ReactiveCocoa-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A87C92CD7C84C8B1F6AF29C71D6CC29 /* ReactiveCocoa-dummy.m */; };
 		8E091F9730391E8389864F5D95311331 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = C051B5B2DCB50742A9CE431F104A17FC /* RACChannel.h */; };
-		901F8BFAB0E2F17BAF42BF79C2D46FA5 /* PVGTableViewRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FEE6ABBDB5CFFAA5FF5B67E4E5F6A5 /* PVGTableViewRenderCommand.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9099F8E7A76EBB0D24C95CCCC77374DB /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B0B1E667C0DBBF9E7F86EBABB8BB89 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		929BA2448BEBD151A7286FAF36547F44 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = DF84D9A1151DF5F102F0B1831F926482 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		932F848B894C4D02BF2EA23FBF3C7C14 /* PVGTableViewSectionHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B65E4F1CE0B9C9C673AA890B09CAC6 /* PVGTableViewSectionHeader.h */; };
+		8E87685B9115815C662318299F6277CB /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 016E13D0CE839315F2AABF99DC2DE7B0 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		90BB51EEF69BB0BC3EF414C9701041B4 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C47003984B71B85C4D2314671004FE51 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		91ADE1263D1167A1E3C5B77AA8D616C6 /* PVGGenericTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9409E1B756C12FD74525B22D1F2EB7D0 /* PVGGenericTableViewProxyAnimator.h */; };
+		929A5E56599DA116B46C9325A4C95E74 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = C639DEFFB1279B61AA75E54B9E7C25F2 /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9443786287E7C2AE7A3E1CDF1520C014 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 68442A0C90D48FC878BCFF5916E7E57F /* RACScopedDisposable.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		94A314DECA51122A78505B62CE56052F /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = D579BDDB82CF91A14F8A28129A566943 /* RACTuple.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		94F2EDAC35ADFEDAF06D7B8CCCB434FA /* UIAlertView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B9B729E874BC492D7764AF6FD4CCD26A /* UIAlertView+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		957587EA75D100E405C88FED19727AB0 /* PVGTableViewProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 601355EC1450EF171590B66154CF584F /* PVGTableViewProxy.h */; };
 		95C420B62360223D8687D9E6AD22D5D5 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F9668BCC293FA91F76BBB9D9BD5B17E3 /* NSArray+RACSequenceAdditions.h */; };
-		99077B4E6A9CE06E9163E6E83A279B34 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D24B57B03698B0CAA4366140998FAC0 /* OCMMacroState.h */; };
+		97DA6B92BA7237C037CEDC3458AE3CBF /* PVGTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D2EB4318FAE845F8F98927FA40984B6 /* PVGTableViewProxyAnimator.h */; };
+		97F7369E1CD96687025F9B3D8D340FC7 /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 866B3F7DD199A25179B34AD7445A95B5 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		996E4773A509E8D6C6F61A293680C92F /* UIButton+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E5E120C429DCB65C7DD2C05F9BEEAEC /* UIButton+RACCommandSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		99A6FDCF475A77B22FEE4992AFC5C6B8 /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4D07ADA801539F0A42A6081DA662D8 /* OCMExceptionReturnValueProvider.h */; };
 		9A007674725B1A416486D680C300AAF0 /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = B076AD76C51CAE345ADE64C725E37ED4 /* RACDynamicSequence.h */; };
-		9A05080A3E73A35B0A0ADEBC8BD30127 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FB8D2684FC592CC91B5AA4FFF8EBBE6 /* OCMStubRecorder.h */; };
 		9A3FE785B92E8A29F4A832531075A844 /* UIStepper+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 593DEDD8FAB8667A243289B476C65075 /* UIStepper+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9A43B5BF2FF9120B0D472E63D73C23FF /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 6139052683DA9D2919C25A9DAFFDA8B6 /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9A5BC5B1AFA52DABB286A19D6E767626 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 360B8725437C04A8EF0BC57F9D428C41 /* NSObject+OCMAdditions.h */; };
 		9A7E04364A64AB6E124B2864A12C9B49 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = D094E57D368A25D9785043D14346E254 /* RACUnit.h */; };
-		9C3BDF068978892F2FA8AFE3A4F831D8 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 812BD09CB5847DF05EC987B30116D22E /* OCMRecorder.h */; };
-		A0F6F9CD05502DA42A6A40A7EB0A357F /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 54B57ED46B3FDA862365AB20071D5E3C /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A17984E76AD5F4BB3E1CF5BE91FCCB41 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A0500FB82C293EB5143F7A158A7246A /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9BA10182C81C1BD22A8FFB468F7467E8 /* PVGTableViewRenderCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 6363335842B97DE79614E400FB760ADF /* PVGTableViewRenderCommand.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9CBADA3A40BDF4E5B4BC506EED0B9F3C /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 950974CBF81BB88BCF1C1D032D033E01 /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9D063125F6E11B22B6D21E79B11BF390 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 16861A8DFD9A3E101C6A8E99E8D93E2D /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A166D011364E50A1D1CB5A7B7BF1662D /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D84D48E9F6039CC5745C6025B7A2314 /* OCMLocation.h */; };
+		A209CA747BF54A00F3ACA7B8A7415318 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8F418B207D53C05C4BACA7FE422B1C /* OCMBlockCaller.h */; };
 		A267B0CD486AC36CF43CBC9B7A8C3032 /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 905F139C1B87E832FBFCA0C499386B14 /* NSArray+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A2D56B281D8E098372CE013D80A911B6 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D64B47D5F5E2176CA3C499A15DDB0437 /* NSInvocation+OCMAdditions.h */; };
 		A304EEE5A36343EC9507C8C57852352B /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = A29C1F74C5EFC2EEBE6AC31215BF8392 /* RACDynamicSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A33D03A255CF452DE6CE88B267065FD6 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = CC49617191AF341E26E453494F00EC3A /* RACTestScheduler.h */; };
-		A4670D4614112A8DC7B2104AEAC93F18 /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 965D4F0182E62F57610C38327B25B11F /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A3F4D398ACCEE24CA1588CB224C01ED9 /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AF99200098BCAE2F4DCB6E0E9DF918 /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A4A2337C8D3175F0DAA92E30B80BAB5E /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = B34B0D63A1F7ACE9BCFA8A421B3525D8 /* RACStringSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A5FBAD1AC3CF04455E93826C8CB1B99B /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = B399772008DA02172F1A21DE7CB43214 /* NSFileHandle+RACSupport.h */; };
 		A6DCD312EC3279A85919A7AEA042BBCA /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E215CC4EE877C62E49E6983E041361B /* RACSequence.h */; };
-		A71D39E10990CF2FA8B7BBBB16BA673E /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D16047A95DE7C3702EFD0FD59FDDD24 /* OCMIndirectReturnValueProvider.h */; };
-		A84E09241E0C52206DE681A9DA3CA614 /* PVGTableViewProxy-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D52AD361DC111A395AE0CAA5F64A774B /* PVGTableViewProxy-dummy.m */; };
 		A95F75FCB0F02FDCF864EE21753FE5F2 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B9F1D7933FB568003EE1D92E69618F0 /* NSObject+RACKVOWrapper.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AED29BA336356D4AE2EC820E6E5BC4E2 /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = B32FF4B288316401FCF396C490AADA92 /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		ACC6E4C4C60CFE44281D246E47BECDAD /* PVGNoAnimationTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6B7F917C0A53CEF473232DCB5ABB03 /* PVGNoAnimationTableViewProxyAnimator.h */; };
 		AF892D6AA9F35B0B47A6237C151B1613 /* UIButton+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A999A7F538AF8A4862AC71F53E83065 /* UIButton+RACCommandSupport.h */; };
 		B09B58248CEAAE882B2092EB23404AAC /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B7CF6D5244515DE2329B227B5B6708 /* NSNotificationCenter+RACSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B0FCBB76A7B658E1F441384AED06A346 /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = E76F89C06792BF0EDC548B2B7A0A7D15 /* NSInvocation+RACTypeParsing.h */; };
@@ -211,112 +220,103 @@
 		B2F3502E0B1BD3E34803E7FA2A12BD28 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FD8DC0DC65D0F996708F553A03833A1 /* UITableViewHeaderFooterView+RACSignalSupport.h */; };
 		B3D0F935F984049151E80233FDCC1114 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = C02DD7524C315129FCDD763AC77D048A /* RACDelegateProxy.h */; };
 		B3E59C91ED1579C2CFCE51AEFA137453 /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 19744226DD1437DA19D843290EBAF926 /* NSDictionary+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B3EE2CF41A058561AFEA52FE6249FC86 /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CDC021235F135AC19120DE041ED3954 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B45923364DBDFF698D9D891BAB648E92 /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = A89A6891E532D68DA63ECC928C450845 /* RACUnit.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B4C4469B89A57C48440567C520EBA7AD /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D602DB1946EBFFF0C82C2098266464 /* RACEvent.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B4E0DE74712D440C62F0534D0D1B9CA0 /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A4FD01EDDBEE42E7E2EC255F52A3CAA /* UITextView+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B591936F20279EF4FF288F2A79918A9A /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = D3773EA7E2C745D785CCE3C9989467E0 /* OCMInvocationStub.h */; };
+		B4E3F85CC26EB5EA9E3424554309C8BC /* PVGTableViewProxy-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 46D72EE4289533EBC86E41CCA64F10BA /* PVGTableViewProxy-dummy.m */; };
 		B5B0CE4D065F73E8B395C75D67AAF342 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = C73F688E5BC94E456D56BC02B1A584D8 /* RACSubscriptingAssignmentTrampoline.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B5DA8E438E68F6EB0582D837B6670BCF /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A95FBBA33A0F0F59621803314BCB125 /* NSEnumerator+RACSequenceAdditions.h */; };
-		B9DD0C572B277805C01E94F79B3B5E84 /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E662F631D7EF7BBD517FFF4EAC5979C5 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B713877003BE6C530457091A7CDAAC59 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 58B4FD0E9B34B7F88A595BC9495176E6 /* OCMRecorder.h */; };
+		B8DE44D4FA5254615B40920CC5E32F27 /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = EF3A4593437E20CA1D7747C8B7CD7CC1 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B9857724CC44E0ADDB1AB9CFFB7DC8D0 /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5491F3B745DC7EF11078528A4268C66B /* NSMethodSignature+OCMAdditions.h */; };
 		BA27F2A17C2AB509C9E00DF157EC59D6 /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DFB9413CC21F448276CEFB574A08902A /* NSIndexSet+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BA45B33961412E113D7AEE437AEABD6A /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = AA72986BFF2C41B26A6F4E2C564F638C /* OCClassMockObject.h */; };
 		BAF8392227AE7ECE270D30A441E47775 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = E4853BC4775668FC24FE5D15A738CB00 /* RACTestScheduler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BC6EA755A60A56B0F5D1097A28D3EE1F /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C5C6BC77ECBA8A7FB39E033E3D87A5C /* NSString+RACKeyPathUtilities.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BDEE812047CA92E098F4791BCDC2EBD0 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE690AA976033A740F0CF81D5958D30 /* OCMBoxedReturnValueProvider.h */; };
 		BDF222AE5324324E5E4792E347A58CB3 /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CE6A88CE9D0A2AB63F299F0B80F2089 /* RACEvent.h */; };
+		BF1CA3ED00A95824C1D0BAE7AABD217B /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EC5254D8A1582F80B3E60B4395D9FD /* NSValue+OCMAdditions.h */; };
 		BF1E9484E565BA462EFBC9FD9DBEF506 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DECBFF5A713DD1C3CA140E410FF85D4 /* RACDelegateProxy.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BF87503F46376297E2190506A87409DE /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFBCAF48652DA9A0D7C2025A6D68F56 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C49137240873DF3A2C4F093238747790 /* PVGTableViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24065F76C971BAEC0F862B117576BE69 /* PVGTableViewProxy.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C1630C99F66538705555CB4D51BBB811 /* OCMock-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C5EBA91D80CD3C5ED58686DD7C7E299 /* OCMock-dummy.m */; };
 		C5537A973E0FD8DCA03B2C41CE91B909 /* RACBacktrace.h in Headers */ = {isa = PBXBuildFile; fileRef = 926ABBD47DCDA26015F4BAB18F6025CF /* RACBacktrace.h */; };
-		C5850D974F80C184310CF82C1E0CBB52 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A02DEB7B1079A6DA19D9629371D97EB /* OCMInvocationExpectation.h */; };
+		C62590EA14C07F3C92FA4EC5EAA57259 /* PVGGenericTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 968F2F0E14AE27986D11FE379D5E52EA /* PVGGenericTableViewProxyAnimator.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C71311E45A5C71192B2E69F0F2510B57 /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A6C5E34582AAE79B79B143134BED9612 /* NSString+RACSequenceAdditions.h */; };
 		C735F10633C278F4A6FB98613DE85786 /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A3EB47188B7F17C00AC9015CC2A5AFA3 /* NSOrderedSet+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C850C91011AAD7B309A6CE99D279D2FF /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = C2C1057DAB64F0DE1BC45963C9E0B3ED /* RACReturnSignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CB3E5BA9EB9ADCA8AB647F7DC2881D6B /* PVGTableViewRenderCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = DCC8E0A51FAF9092C95DCC4E9EB50710 /* PVGTableViewRenderCommand.h */; };
+		C88CB4F610E9847F915E7737B22DE446 /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = EFBED41199BA448B71D5B949905C2295 /* OCMBlockArgCaller.h */; };
+		CC05D18E18D8F4158F8A2F9F76BA4E2D /* PVGTableViewScrollCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C057A956252EDCFDD209C63B6F531 /* PVGTableViewScrollCommand.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CCC645F69382F23EC36C81381A467B4B /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = C89F3E316704C3CEBC72CA450533CF16 /* RACTupleSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CD4049E4CB3B830FD5D803995271B8E7 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 31143B31D13AA92A24746BD4BCAF2369 /* NSObject+RACSelectorSignal.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CD4D9F108A8D8F9C927CBCEEBC6BA03C /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 075E727F4BA143EC4358DAB6C5B5778A /* NSObject+OCMAdditions.h */; };
-		CD7ABDEB1B37867ABBBB54577BAB2F66 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 267D34AA96EA417369DCD7169B5AFABD /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CDA4C0B55F3494BC0544336E6D49A5AB /* PVGTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = E65544594098B238CB4F2691EE652C07 /* PVGTableViewCell.h */; };
-		CE0A4ED8BF97F70D4A07497C06C03D48 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 13936049D59FA813E22D3A74A5F7B2CE /* OCMConstraint.h */; };
-		CE296C0D6BEAEFF6704155BC4347632A /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 20C6E7A44A84C5BB5EFA32CC3F514288 /* NSNotificationCenter+OCMAdditions.h */; };
 		CEAE611C4F976A908C9BF7D494C87CC9 /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = F3E5702AC9C4052BEB95C01C7BC40DC4 /* RACImmediateScheduler.h */; };
 		D037B07C1674084F1D849E987481FCFB /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E42A7721104595CF8F07FF6F53C586A /* RACStream.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D0C91D823CCB007BA70D8A8B221BCFEF /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CAC2E2BC839F97F9A4151270755DA02 /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D20060AD4776A5BE36A813CA4DF438D8 /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A19127A8973D028E4CB60C290D97B8F /* RACScheduler+Subclass.h */; };
-		D25E1F6864F822D7F9F56D3CB1A5F551 /* PVGTableViewSimpleDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 84DBCCE329925DD71E14A8D868932804 /* PVGTableViewSimpleDataSource.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D2D97E132174477B91FEEE6E6FF1FA40 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = F1628388550DF248C5F30FF4B27859B9 /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D4EBCCD3E477673068C6F1B9FFB32DB9 /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D957B9EAF06986CD15C18E2F0E3DBCD /* RACGroupedSignal.h */; };
-		D5D38BA0BA8BD29DFF4244737895C9CD /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E298C4F7D8B0502B6A8E0D31EC2E254 /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D4F809187FA52BB0957B0B9847B737BB /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 98B01105C0B20827F1337B1CA4FFD72B /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D5D9AABE9BE92A96444434FEFD4F8D6D /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D80BD19BCD22037F8B73C012EC4F5DF /* UIBarButtonItem+RACCommandSupport.h */; };
 		D61FD7322FF17B32C1624E36AA9E8BFB /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 54C293CEBE72158C11BE4A9890EF2DC2 /* RACChannel.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D6791052A919FE2BC6775A6046872464 /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = E8C546FD95411FB5EE2B8EE722F188AE /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D65A4C4D755682367D4319CC0D96D4D2 /* PVGTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 950A8699AB199E57E60FA5BAEFB8F3FA /* PVGTableViewDataSource.h */; };
 		D7151ABAD5DE3586DD85E817B6A77048 /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D2210909C9815A7F677E56C73A869 /* RACMulticastConnection+Private.h */; };
 		D7619E10B0676F278F3152B083D83CF4 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1AC93913D79183EFC6FD7C965B4AE3 /* NSUserDefaults+RACSupport.h */; };
 		D82C414BBFB184C26419BB5F9C7FBF93 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D7A7A322B65DACBDA9ED92B41A4B55D /* RACCompoundDisposable.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DD1BDDB93C75C4A0B53D43C71FC5C47B /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 88C19BAC90FBBFA3148A7FA3DE2A314E /* OCMLocation.h */; };
+		DD9F19A9C50B79BA79402EC31812C7A6 /* PVGTableViewSection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0151C01A1729858C7D66FB916EDA17B9 /* PVGTableViewSection.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DE14896FD4216D47AD1FA0E7B5DA7988 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = C625CD9258C8B36AF99D5B25F47FEF28 /* RACCompoundDisposable.h */; };
 		E0132987561816758E063B7B19366D7C /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 145ED98A6E9AAE6E4FC6DF2480DE1E2F /* RACKVOTrampoline.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E053EB0F7CE321C792CBCFE96DFE8981 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D35EE7E712885A7D0D20169862277F1 /* RACTuple.h */; };
-		E0A68F95CBEAE556A41299F87E5A075D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
-		E1ECAE9EE0D97CCC4A2B0CA331ADA441 /* PVGTableViewSectionHeaderViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 75AD99C4F0AB71CC0E6854E7E8376C29 /* PVGTableViewSectionHeaderViewModel.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E3A719B4F051A421FA752E0F4B2C1550 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 585496D12D02F30012532E923DEBB9C7 /* OCMockObject.h */; };
+		E0A783AB1B7C425228D8C066D97037C7 /* PVGTableViewSimpleDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F394E0BD3AAAF4525C8D266BC815259 /* PVGTableViewSimpleDataSource.h */; };
+		E154D2F83C5C127905CA701EBBF03545 /* PVGNoAnimationTableViewProxyAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 871EDC5A483BBD7E7A4D8C1E86D58B2E /* PVGNoAnimationTableViewProxyAnimator.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E33075E208008574A3411584C70428CD /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 666AE31483568C2B4F8CF3FC24104222 /* OCMArgAction.h */; };
 		E3D1EE70DD968AC5DCCB6964C29B98A3 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 33FBE48FB50B5C5158671B8B7D4A9006 /* NSString+RACSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E5FE3B82FE89DF337DE94435AFCA63E7 /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = C6EF1C2A03766C2E31197D4B012C1506 /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E5B9C6476DC0B4CC8FB94117E83942BC /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = DB4BEE5FAF865B4C6D95663C675FDB75 /* OCMInvocationMatcher.h */; };
 		E6FCB7ABEFD716BF149F4E33436336D9 /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F8FB48AD6E01B580EB71D5412CA100E /* RACTargetQueueScheduler.h */; };
 		E7356DD4022C1C8DB7DAD957BE36CFC7 /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = A364F4B47B0AD3047B148D67BDAB3564 /* RACReplaySubject.h */; };
-		E79C3C5B1AA9A34A07F540C9728BF74B /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = F5B03E8D8A70ACB7797E40270085A07B /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E87E543AC297CAF11209989F5CE47C8B /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F6C302E7DE074A5168C21A132E43AEC /* RACPassthroughSubscriber.h */; };
-		E91E61A5D774A1941B0396D8DE1C3F1C /* PVGGenericTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 12A364438861FE1676109C76086F1708 /* PVGGenericTableViewProxyAnimator.h */; };
 		EA64D458CAA386DD83BDCBAB72D81F4E /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = B3B11C192C0B046402E0FAAACBE01FD2 /* RACSerialDisposable.h */; };
 		EA830E3C2A886BCC82901B332EF0F28E /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 35FB5B163C46BD845176B87D265CA5D8 /* RACQueueScheduler.h */; };
 		EA9D506E0E0362AA01C246F8C4DAD506 /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = B56497B2918A5A0E56AAF26D73A4B878 /* RACBlockTrampoline.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EADB0111F08AFE4F721705742FCC3AE5 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = E65A4F1D0D574E043B87736F9337775C /* RACSignalProvider.d */; };
 		EC227D2DDBE43CD1D8C65266C456AF59 /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = E1FABCB0E89CAAA52AD258ECAF97C9B9 /* RACIndexSetSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EC5CE6E3D0C87865BE25B6F70AAB2AE4 /* PVGNoAnimationTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CCFA7CE9502200FC46AA40B69BC92F3 /* PVGNoAnimationTableViewProxyAnimator.h */; };
 		EE69B502E0BF5BFE9CC1FE2463DF9F8C /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = FF9300518235D238F740EF249EABF447 /* RACKVOChannel.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EFA06C72F7C6E379118AC955E3E04E47 /* RACEXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = C7CBD7D718CEE3FE4466BF512532C1A3 /* RACEXTKeyPathCoding.h */; };
-		F07C72F58E6ED099168F495D2D1707F7 /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 53177876B15AB525D8E50007F07A9B06 /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EFB603A1676333FE995E02665FD4C7FB /* PVGTableViewSectionHeaderViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 02165B7C6E85359D228DC1197023E0E2 /* PVGTableViewSectionHeaderViewModel.h */; };
 		F14B0BFD13510DF64D388E17EDDB3A2F /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = FC042EB387C07EB55D8EAAEBFC2ED404 /* RACScheduler.h */; };
 		F2BDA650792C0D706C0FE9E69EBE9920 /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = 5487BF0703B0F1953F9AD014F3B3FDA1 /* RACSubscriptionScheduler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F4A95524991B6F867A151AFBF23B12AB /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 81074940930775A6B73C6D5690004993 /* OCMVerifier.h */; };
-		F4DDA686AB64DC7F88DCC269FA6D4E23 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 528D81DEB3C59A9C603DFF8C83248E0C /* OCPartialMockObject.h */; };
+		F3DBABB779292CD3415E62B3BADCAEB5 /* PVGTableViewSectionHeaderViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F8A9A168015EEC1A00990A9F39086FA /* PVGTableViewSectionHeaderViewModel.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F4F0EAA36C4316AEC98220F1C92DFC0F /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = BA27CB459488D8A7D1488B57930EB26A /* RACSignalSequence.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F6FFF2AB993351B02B411D8A670800E9 /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = F1C37132F4CD4AED2917B637E30FB7EA /* RACErrorSignal.h */; };
-		F7EAAF9E990F2AA9EC014FC801F1EAC9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */; };
 		F86BA441CF4B25C47FE9AF11460B37C3 /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 94471863AFA368A15D8BCD5ABD0205AB /* RACEmptySignal.h */; };
-		F96A07C71960FA80D4A9EB055F8ACA1B /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = C8367006F792E1854698F04C2260A9BD /* OCMNotificationPoster.h */; };
-		FA04865910A96462123E0A1AA2841B59 /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D801CB6F835721F575C154D6EC95CDD /* OCMBlockArgCaller.h */; };
 		FA85FBE34F2CB7AE0BB61632AFC1DB2E /* RACBacktrace.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BE0E56655428E836EA2EE5069758183 /* RACBacktrace.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FACC60021354E0AD1BAC251D434D42C3 /* UITextField+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D54D194720BA374E3DC61A6073D013A5 /* UITextField+RACSignalSupport.h */; };
+		FB1C69B2D6859BBB036B9978D315F8B5 /* PVGTableViewCellViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B75A71085B82C972E5724BC4B51AAB /* PVGTableViewCellViewModel.h */; };
 		FC4967822955D17471DD02C2658DDAC3 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EE68225A0062C61B8E49D5AA671F197 /* NSEnumerator+RACSequenceAdditions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FCB357B6F774F753DA7E70A627631535 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = F9DC4BFDE58242C6ECB77EBA04F42F13 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FD36D97A9EBE7A9182F48462A7F51063 /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C93C5C6C629769B8496CB486461F2961 /* UITableViewHeaderFooterView+RACSignalSupport.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FDF012024867FABF75599D896FCA21B5 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 70711C1A6DCDA7C32368789F5B722CAB /* OCMObserverRecorder.h */; };
-		FE0A205BED60AAF3444F27B8A5B2A375 /* PVGTableViewProxyAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD7398CD3504557EFDF05D5411AF244 /* PVGTableViewProxyAnimator.h */; };
 		FE7C3909004BEA9C134E333343B6D004 /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAB52083E14D6178D64FAA27E7DB6A /* RACScopedDisposable.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		2233C5BFE78B3CE4D9C34FE28DC58559 /* PBXContainerItemProxy */ = {
+		3BF0F37C59AC54C4985691D01ABBAAB0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4605D3A79D4D4065E5824B51B1F59438;
+			remoteGlobalIDString = 3CE42A70E6AB364CFC64E633F663BCC4;
+			remoteInfo = OCMock;
+		};
+		7F424D5B33724B031218C1B5FC94DEBD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D2B52569AD117BAD7C6F9E4C8EE15975;
 			remoteInfo = PVGTableViewProxy;
 		};
-		95034FEA22AEBF59775543E4909D8695 /* PBXContainerItemProxy */ = {
+		9F2EDBD27857F90D2F9BF478E6BFE842 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = D76319C99A3017CFE90D0DE010012BAD;
 			remoteInfo = ReactiveCocoa;
 		};
-		9893A5B45552656093930C26A422BCE8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CDE88E0D36B79134D5D549BEFD328433;
-			remoteInfo = OCMock;
-		};
-		A952B0BCDFD702755EAF0A6B3818313D /* PBXContainerItemProxy */ = {
+		A738FCAA689FD5F2465C3EC051D1986D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
@@ -326,130 +326,132 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00368C2B27F8B758D3EE22FBEA8E3298 /* OCClassMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCClassMockObject.m; path = Source/OCMock/OCClassMockObject.m; sourceTree = "<group>"; };
+		00759EFCBBF0E79AD01414A9B9EC4EF6 /* OCMRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRecorder.m; path = Source/OCMock/OCMRecorder.m; sourceTree = "<group>"; };
+		00779B7557C38374810DC1E9A2585C4C /* PVGTableViewRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewRenderCommand.h; sourceTree = "<group>"; };
+		0151C01A1729858C7D66FB916EDA17B9 /* PVGTableViewSection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSection.m; sourceTree = "<group>"; };
+		016E13D0CE839315F2AABF99DC2DE7B0 /* NSNotificationCenter+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+OCMAdditions.m"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.m"; sourceTree = "<group>"; };
+		02165B7C6E85359D228DC1197023E0E2 /* PVGTableViewSectionHeaderViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeaderViewModel.h; sourceTree = "<group>"; };
 		02785933B4E28BB3A0F7EB65005B6543 /* UITableViewCell+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewCell+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.h"; sourceTree = "<group>"; };
 		0313CA92A67C11509BC7D9B90344D6B7 /* NSURLConnection+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+RACSupport.h"; path = "ReactiveCocoa/NSURLConnection+RACSupport.h"; sourceTree = "<group>"; };
+		03AF99200098BCAE2F4DCB6E0E9DF918 /* NSMethodSignature+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+OCMAdditions.m"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.m"; sourceTree = "<group>"; };
 		04D602DB1946EBFFF0C82C2098266464 /* RACEvent.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEvent.m; path = ReactiveCocoa/RACEvent.m; sourceTree = "<group>"; };
-		06B2C4C53B4320316B5F030A895E7BF3 /* OCMRealObjectForwarder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRealObjectForwarder.m; path = Source/OCMock/OCMRealObjectForwarder.m; sourceTree = "<group>"; };
-		075E727F4BA143EC4358DAB6C5B5778A /* NSObject+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+OCMAdditions.h"; path = "Source/OCMock/NSObject+OCMAdditions.h"; sourceTree = "<group>"; };
 		0847F72083B2F953FB11CD003921B2E8 /* ReactiveCocoa-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ReactiveCocoa-Private.xcconfig"; sourceTree = "<group>"; };
-		0A02DEB7B1079A6DA19D9629371D97EB /* OCMInvocationExpectation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationExpectation.h; path = Source/OCMock/OCMInvocationExpectation.h; sourceTree = "<group>"; };
 		0A69226374214E7F69EAD30964973489 /* RACMulticastConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACMulticastConnection.m; path = ReactiveCocoa/RACMulticastConnection.m; sourceTree = "<group>"; };
 		0C3310059DFDF761BE07487D9CE4F041 /* UICollectionReusableView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UICollectionReusableView+RACSignalSupport.m"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		0C5C6BC77ECBA8A7FB39E033E3D87A5C /* NSString+RACKeyPathUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACKeyPathUtilities.m"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.m"; sourceTree = "<group>"; };
-		0D95B7E1C217581D6C85FE670C44C75B /* OCMReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMReturnValueProvider.h; path = Source/OCMock/OCMReturnValueProvider.h; sourceTree = "<group>"; };
+		0C5EBA91D80CD3C5ED58686DD7C7E299 /* OCMock-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OCMock-dummy.m"; sourceTree = "<group>"; };
+		0D7FD8FA1E348598C720747E570634A6 /* NSValue+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+OCMAdditions.m"; path = "Source/OCMock/NSValue+OCMAdditions.m"; sourceTree = "<group>"; };
 		0E215CC4EE877C62E49E6983E041361B /* RACSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSequence.h; path = ReactiveCocoa/RACSequence.h; sourceTree = "<group>"; };
+		0E8C057A956252EDCFDD209C63B6F531 /* PVGTableViewScrollCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewScrollCommand.m; sourceTree = "<group>"; };
 		0FA00593500EBEDF8EA741B304A2E1F6 /* NSData+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+RACSupport.m"; path = "ReactiveCocoa/NSData+RACSupport.m"; sourceTree = "<group>"; };
 		0FE629FEFD8701CFC7E220B7E4F51EC2 /* RACEXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTScope.h; path = ReactiveCocoa/extobjc/RACEXTScope.h; sourceTree = "<group>"; };
-		1262D6ACE7E257C1CCF4C830B282F1A3 /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Source/OCMock/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
-		12A364438861FE1676109C76086F1708 /* PVGGenericTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGGenericTableViewProxyAnimator.h; sourceTree = "<group>"; };
-		13936049D59FA813E22D3A74A5F7B2CE /* OCMConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMConstraint.h; path = Source/OCMock/OCMConstraint.h; sourceTree = "<group>"; };
 		145ED98A6E9AAE6E4FC6DF2480DE1E2F /* RACKVOTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOTrampoline.m; path = ReactiveCocoa/RACKVOTrampoline.m; sourceTree = "<group>"; };
 		14C127A7DF26F806FB0A86D715D3F76C /* RACEmptySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySequence.m; path = ReactiveCocoa/RACEmptySequence.m; sourceTree = "<group>"; };
+		16570164A52BE2E3DD5CB6572A35573F /* OCProtocolMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCProtocolMockObject.m; path = Source/OCMock/OCProtocolMockObject.m; sourceTree = "<group>"; };
+		16861A8DFD9A3E101C6A8E99E8D93E2D /* OCMFunctions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMFunctions.m; path = Source/OCMock/OCMFunctions.m; sourceTree = "<group>"; };
 		16DCE8BE4EDE00588F338BC951937A99 /* RACErrorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACErrorSignal.m; path = ReactiveCocoa/RACErrorSignal.m; sourceTree = "<group>"; };
 		19744226DD1437DA19D843290EBAF926 /* NSDictionary+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		19B450BDFA71F70143195DA2092E8F6F /* NSFileHandle+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileHandle+RACSupport.m"; path = "ReactiveCocoa/NSFileHandle+RACSupport.m"; sourceTree = "<group>"; };
 		1A4F1EF66BE0A526F56C1563715D7E6B /* ReactiveCocoa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ReactiveCocoa.xcconfig; sourceTree = "<group>"; };
 		1A4FD01EDDBEE42E7E2EC255F52A3CAA /* UITextView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextView+RACSignalSupport.m"; path = "ReactiveCocoa/UITextView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		1BE0E56655428E836EA2EE5069758183 /* RACBacktrace.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBacktrace.m; path = ReactiveCocoa/RACBacktrace.m; sourceTree = "<group>"; };
-		1D16047A95DE7C3702EFD0FD59FDDD24 /* OCMIndirectReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMIndirectReturnValueProvider.h; path = Source/OCMock/OCMIndirectReturnValueProvider.h; sourceTree = "<group>"; };
+		1CDC021235F135AC19120DE041ED3954 /* OCMReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMReturnValueProvider.m; path = Source/OCMock/OCMReturnValueProvider.m; sourceTree = "<group>"; };
+		1D89D360A67C35D7C01465F95D4BF29D /* OCMArgAction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArgAction.m; path = Source/OCMock/OCMArgAction.m; sourceTree = "<group>"; };
 		1DA2747950788C668FEB126121009655 /* UISegmentedControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISegmentedControl+RACSignalSupport.h"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.h"; sourceTree = "<group>"; };
 		1E42A7721104595CF8F07FF6F53C586A /* RACStream.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStream.m; path = ReactiveCocoa/RACStream.m; sourceTree = "<group>"; };
 		1FD8DC0DC65D0F996708F553A03833A1 /* UITableViewHeaderFooterView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableViewHeaderFooterView+RACSignalSupport.h"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		20C6E7A44A84C5BB5EFA32CC3F514288 /* NSNotificationCenter+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+OCMAdditions.h"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.h"; sourceTree = "<group>"; };
 		2118D3D33407B762E104CA8CAA844993 /* RACCompoundDisposableProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACCompoundDisposableProvider.d; path = ReactiveCocoa/RACCompoundDisposableProvider.d; sourceTree = "<group>"; };
 		217D2210909C9815A7F677E56C73A869 /* RACMulticastConnection+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACMulticastConnection+Private.h"; path = "ReactiveCocoa/RACMulticastConnection+Private.h"; sourceTree = "<group>"; };
 		21EA8575483C4E7C762146F6B054CE29 /* NSObject+RACDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDescription.h"; path = "ReactiveCocoa/NSObject+RACDescription.h"; sourceTree = "<group>"; };
-		23B65E4F1CE0B9C9C673AA890B09CAC6 /* PVGTableViewSectionHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeader.h; sourceTree = "<group>"; };
-		24065F76C971BAEC0F862B117576BE69 /* PVGTableViewProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewProxy.m; sourceTree = "<group>"; };
+		2299EEA967B0DD3636A96411075A2D00 /* OCMExpectationRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExpectationRecorder.m; path = Source/OCMock/OCMExpectationRecorder.m; sourceTree = "<group>"; };
+		24B0F3D2E21AAEC48B2FC12808AF2DC7 /* PVGTableViewProxy-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "PVGTableViewProxy-Private.xcconfig"; sourceTree = "<group>"; };
 		259A96310123EEBAE08CD792E8B04F1B /* NSSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		2640B557DCB791022E6C94DF90931DA6 /* UITableViewCell+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewCell+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewCell+RACSignalSupport.m"; sourceTree = "<group>"; };
-		267D34AA96EA417369DCD7169B5AFABD /* OCMFunctions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMFunctions.m; path = Source/OCMock/OCMFunctions.m; sourceTree = "<group>"; };
+		26EB63963AB04C503AA348BA83CC02A0 /* OCMInvocationExpectation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationExpectation.h; path = Source/OCMock/OCMInvocationExpectation.h; sourceTree = "<group>"; };
 		29FAB52083E14D6178D64FAA27E7DB6A /* RACScopedDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScopedDisposable.h; path = ReactiveCocoa/RACScopedDisposable.h; sourceTree = "<group>"; };
 		2A19127A8973D028E4CB60C290D97B8F /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
 		2A3C1D9D5D867A955FA26D85403C665F /* UISlider+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISlider+RACSignalSupport.m"; path = "ReactiveCocoa/UISlider+RACSignalSupport.m"; sourceTree = "<group>"; };
 		2B85ACF4425F2273A55FC61AF7AC7F9E /* UIImagePickerController+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImagePickerController+RACSignalSupport.h"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.h"; sourceTree = "<group>"; };
 		2BAB85A2CC1046842ACE5B1749380D9A /* UIActionSheet+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+RACSignalSupport.m"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.m"; sourceTree = "<group>"; };
-		2CCFA7CE9502200FC46AA40B69BC92F3 /* PVGNoAnimationTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGNoAnimationTableViewProxyAnimator.h; sourceTree = "<group>"; };
-		2D24B57B03698B0CAA4366140998FAC0 /* OCMMacroState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMMacroState.h; path = Source/OCMock/OCMMacroState.h; sourceTree = "<group>"; };
+		2CAC2E2BC839F97F9A4151270755DA02 /* OCMBlockCaller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBlockCaller.m; path = Source/OCMock/OCMBlockCaller.m; sourceTree = "<group>"; };
 		2D64AFC4855D4951AF20E2A15CF6B42C /* UIDatePicker+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIDatePicker+RACSignalSupport.h"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.h"; sourceTree = "<group>"; };
 		2DECBFF5A713DD1C3CA140E410FF85D4 /* RACDelegateProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDelegateProxy.m; path = ReactiveCocoa/RACDelegateProxy.m; sourceTree = "<group>"; };
-		2DFBCAF48652DA9A0D7C2025A6D68F56 /* OCObserverMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCObserverMockObject.m; path = Source/OCMock/OCObserverMockObject.m; sourceTree = "<group>"; };
 		2E5E120C429DCB65C7DD2C05F9BEEAEC /* UIButton+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+RACCommandSupport.m"; path = "ReactiveCocoa/UIButton+RACCommandSupport.m"; sourceTree = "<group>"; };
-		3023AC99DF52D11654C7AEBCB8EB6BD4 /* PVGTableViewSection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSection.h; sourceTree = "<group>"; };
+		2F394E0BD3AAAF4525C8D266BC815259 /* PVGTableViewSimpleDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSimpleDataSource.h; sourceTree = "<group>"; };
 		31143B31D13AA92A24746BD4BCAF2369 /* NSObject+RACSelectorSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACSelectorSignal.m"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.m"; sourceTree = "<group>"; };
-		318C4F9E950AAE22319EFA25180621FD /* NSNotificationCenter+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+OCMAdditions.m"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.m"; sourceTree = "<group>"; };
 		323F3AC4553E14CBF18E3BD1879BDE94 /* RACTupleSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTupleSequence.h; path = ReactiveCocoa/RACTupleSequence.h; sourceTree = "<group>"; };
-		33DEA5BA89EAF43034EC22A9F95F179B /* PVGTableViewDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewDataSource.h; sourceTree = "<group>"; };
+		33EC5254D8A1582F80B3E60B4395D9FD /* NSValue+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+OCMAdditions.h"; path = "Source/OCMock/NSValue+OCMAdditions.h"; sourceTree = "<group>"; };
 		33FBE48FB50B5C5158671B8B7D4A9006 /* NSString+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSupport.m"; path = "ReactiveCocoa/NSString+RACSupport.m"; sourceTree = "<group>"; };
 		342812A379B74454B8C6795EF46E1C5A /* RACStringSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStringSequence.h; path = ReactiveCocoa/RACStringSequence.h; sourceTree = "<group>"; };
+		345967331A372F93EFA1890814C86068 /* OCMBoxedReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBoxedReturnValueProvider.h; path = Source/OCMock/OCMBoxedReturnValueProvider.h; sourceTree = "<group>"; };
 		35FB5B163C46BD845176B87D265CA5D8 /* RACQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACQueueScheduler.h; path = ReactiveCocoa/RACQueueScheduler.h; sourceTree = "<group>"; };
+		360B8725437C04A8EF0BC57F9D428C41 /* NSObject+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+OCMAdditions.h"; path = "Source/OCMock/NSObject+OCMAdditions.h"; sourceTree = "<group>"; };
 		363B167073F14012BA2D632CBE1A4F80 /* ReactiveCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ReactiveCocoa-prefix.pch"; sourceTree = "<group>"; };
 		3692CADEBCEE54F58CFBCA9C0D49764B /* RACUnarySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnarySequence.m; path = ReactiveCocoa/RACUnarySequence.m; sourceTree = "<group>"; };
-		37680914889200B2B9050743215DBBCB /* OCMFunctions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctions.h; path = Source/OCMock/OCMFunctions.h; sourceTree = "<group>"; };
+		36A5248683C4E55F6204D49CC45449AD /* PVGTableViewSimpleDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSimpleDataSource.m; sourceTree = "<group>"; };
 		37D709F35746AA6116789A7E67C58856 /* RACArraySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACArraySequence.h; path = ReactiveCocoa/RACArraySequence.h; sourceTree = "<group>"; };
 		3A1AC93913D79183EFC6FD7C965B4AE3 /* NSUserDefaults+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSUserDefaults+RACSupport.h"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.h"; sourceTree = "<group>"; };
 		3ABFA4091A89C6B20591C4E668D4A84C /* NSUserDefaults+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSUserDefaults+RACSupport.m"; path = "ReactiveCocoa/NSUserDefaults+RACSupport.m"; sourceTree = "<group>"; };
 		3B00CD4796DC365642F1FD6FD66D1C72 /* NSNotificationCenter+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+RACSupport.h"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.h"; sourceTree = "<group>"; };
 		3B4C933FECE1CDE00719BAD43AFB2287 /* NSObject+RACPropertySubscribing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACPropertySubscribing.h"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.h"; sourceTree = "<group>"; };
-		3CD190E1B287D46CB8B84BA505D3D283 /* libOCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CF88006BAB6F984CFD4CCDA2EA4430A /* OCMock-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OCMock-prefix.pch"; sourceTree = "<group>"; };
+		3D27096DDEEDC45EA2F21232B4D3A8EC /* OCMStubRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMStubRecorder.h; path = Source/OCMock/OCMStubRecorder.h; sourceTree = "<group>"; };
 		3D957B9EAF06986CD15C18E2F0E3DBCD /* RACGroupedSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACGroupedSignal.h; path = ReactiveCocoa/RACGroupedSignal.h; sourceTree = "<group>"; };
+		3DE12809B21B09380C7106A8C88C00BD /* PVGTableViewScrollCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewScrollCommand.h; sourceTree = "<group>"; };
 		3ECE3636B2F44E26A268736AE7D1B8F2 /* RACScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScheduler.m; path = ReactiveCocoa/RACScheduler.m; sourceTree = "<group>"; };
 		3EE68225A0062C61B8E49D5AA671F197 /* NSEnumerator+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSEnumerator+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		3EFAFB57EE6CA3C122D820FA12685EB9 /* RACEagerSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEagerSequence.h; path = ReactiveCocoa/RACEagerSequence.h; sourceTree = "<group>"; };
+		3F0610842A13AFB6055709F664887F45 /* OCPartialMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCPartialMockObject.m; path = Source/OCMock/OCPartialMockObject.m; sourceTree = "<group>"; };
 		3F6C302E7DE074A5168C21A132E43AEC /* RACPassthroughSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACPassthroughSubscriber.h; path = ReactiveCocoa/RACPassthroughSubscriber.h; sourceTree = "<group>"; };
 		40D1DAB6CDF14063CC2EAD478C794D60 /* RACIndexSetSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACIndexSetSequence.h; path = ReactiveCocoa/RACIndexSetSequence.h; sourceTree = "<group>"; };
-		42FD7E848AABCAF8C97EF727DD712BD7 /* OCMExpectationRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExpectationRecorder.m; path = Source/OCMock/OCMExpectationRecorder.m; sourceTree = "<group>"; };
 		430B51A6F3628BC3B45B84F3D857CC87 /* NSObject+RACKVOWrapper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACKVOWrapper.h"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.h"; sourceTree = "<group>"; };
-		46D48BDC8A8AB37DCD86A40A66E88ED3 /* OCMMacroState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMMacroState.m; path = Source/OCMock/OCMMacroState.m; sourceTree = "<group>"; };
-		47B7272403ACA6E3D6558E4A7BE31D17 /* OCMock-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OCMock-dummy.m"; sourceTree = "<group>"; };
+		46D72EE4289533EBC86E41CCA64F10BA /* PVGTableViewProxy-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PVGTableViewProxy-dummy.m"; sourceTree = "<group>"; };
+		48A6541559C7DADE343D7A70D973391A /* OCMBlockArgCaller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBlockArgCaller.m; path = Source/OCMock/OCMBlockArgCaller.m; sourceTree = "<group>"; };
 		493A4CF157B8BD3271E6C3B7F19810D2 /* NSObject+RACDeallocating.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDeallocating.m"; path = "ReactiveCocoa/NSObject+RACDeallocating.m"; sourceTree = "<group>"; };
 		49DFABFDE2144F35EC2E3064DAD62BB7 /* NSString+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		49F83A0E46824B501A3B42347E730DDF /* OCMVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMVerifier.m; path = Source/OCMock/OCMVerifier.m; sourceTree = "<group>"; };
-		4C8C7366D1C9E2044EC9EAAA51DF743D /* PVGTableViewSectionHeaderViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeaderViewModel.h; sourceTree = "<group>"; };
+		4D4D07ADA801539F0A42A6081DA662D8 /* OCMExceptionReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExceptionReturnValueProvider.h; path = Source/OCMock/OCMExceptionReturnValueProvider.h; sourceTree = "<group>"; };
+		4D4EE0C6D45024778A4070BE5B352D51 /* OCMObserverRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMObserverRecorder.h; path = Source/OCMock/OCMObserverRecorder.h; sourceTree = "<group>"; };
 		4ED2D85CEBC801B17B542A20C4586B6B /* NSData+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+RACSupport.h"; path = "ReactiveCocoa/NSData+RACSupport.h"; sourceTree = "<group>"; };
-		4FADAACFC4CB488D7021A0E795B11177 /* OCMPassByRefSetter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMPassByRefSetter.h; path = Source/OCMock/OCMPassByRefSetter.h; sourceTree = "<group>"; };
 		4FF2B4C40E6B53880C8E24B78B0F7832 /* RACBehaviorSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBehaviorSubject.h; path = ReactiveCocoa/RACBehaviorSubject.h; sourceTree = "<group>"; };
 		50573FB164780E69532A8E40FE14D9F6 /* UIDatePicker+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIDatePicker+RACSignalSupport.m"; path = "ReactiveCocoa/UIDatePicker+RACSignalSupport.m"; sourceTree = "<group>"; };
 		50CCFF25C487E8C2A2C4305939BD58D9 /* RACScheduler+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Private.h"; path = "ReactiveCocoa/RACScheduler+Private.h"; sourceTree = "<group>"; };
 		50CD25838196EF77602DC8A2D9AB669F /* NSObject+RACSelectorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACSelectorSignal.h"; path = "ReactiveCocoa/NSObject+RACSelectorSignal.h"; sourceTree = "<group>"; };
-		528D81DEB3C59A9C603DFF8C83248E0C /* OCPartialMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCPartialMockObject.h; path = Source/OCMock/OCPartialMockObject.h; sourceTree = "<group>"; };
-		53177876B15AB525D8E50007F07A9B06 /* OCMIndirectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMIndirectReturnValueProvider.m; path = Source/OCMock/OCMIndirectReturnValueProvider.m; sourceTree = "<group>"; };
+		5465C01CB9D4D3ECB7AE33E1DF2B8BC5 /* OCMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMockObject.m; path = Source/OCMock/OCMockObject.m; sourceTree = "<group>"; };
 		5487BF0703B0F1953F9AD014F3B3FDA1 /* RACSubscriptionScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptionScheduler.m; path = ReactiveCocoa/RACSubscriptionScheduler.m; sourceTree = "<group>"; };
-		54B57ED46B3FDA862365AB20071D5E3C /* OCMLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMLocation.m; path = Source/OCMock/OCMLocation.m; sourceTree = "<group>"; };
+		5491F3B745DC7EF11078528A4268C66B /* NSMethodSignature+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+OCMAdditions.h"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.h"; sourceTree = "<group>"; };
 		54C293CEBE72158C11BE4A9890EF2DC2 /* RACChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACChannel.m; path = ReactiveCocoa/RACChannel.m; sourceTree = "<group>"; };
-		556FD396E58E585893DFCDDFCE252104 /* OCMInvocationExpectation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationExpectation.m; path = Source/OCMock/OCMInvocationExpectation.m; sourceTree = "<group>"; };
-		585496D12D02F30012532E923DEBB9C7 /* OCMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMockObject.h; path = Source/OCMock/OCMockObject.h; sourceTree = "<group>"; };
-		58C91BFC78E6400DB7A70EC0B4835702 /* OCMArgAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArgAction.h; path = Source/OCMock/OCMArgAction.h; sourceTree = "<group>"; };
+		58B4FD0E9B34B7F88A595BC9495176E6 /* OCMRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRecorder.h; path = Source/OCMock/OCMRecorder.h; sourceTree = "<group>"; };
 		593DEDD8FAB8667A243289B476C65075 /* UIStepper+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIStepper+RACSignalSupport.m"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.m"; sourceTree = "<group>"; };
 		5A306134FA1B70D83AC83C8A45D54287 /* NSString+RACKeyPathUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACKeyPathUtilities.h"; path = "ReactiveCocoa/NSString+RACKeyPathUtilities.h"; sourceTree = "<group>"; };
 		5A7E545F8BA80D2A6652305B16FFB89A /* RACPassthroughSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACPassthroughSubscriber.m; path = ReactiveCocoa/RACPassthroughSubscriber.m; sourceTree = "<group>"; };
+		5B32918FD0D459981A25930AD07F6B52 /* OCMFunctions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctions.h; path = Source/OCMock/OCMFunctions.h; sourceTree = "<group>"; };
 		5C80957307F6AD9FED8E80639FA98627 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		5D35EE7E712885A7D0D20169862277F1 /* RACTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTuple.h; path = ReactiveCocoa/RACTuple.h; sourceTree = "<group>"; };
 		5E5167B723330C59160193234EB2202E /* RACBlockTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBlockTrampoline.h; path = ReactiveCocoa/RACBlockTrampoline.h; sourceTree = "<group>"; };
 		5ECC43BD36BA05CE80622EF6CE10828C /* PVGTableViewProxy-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PVGTableViewProxy-prefix.pch"; sourceTree = "<group>"; };
-		5FB8D2684FC592CC91B5AA4FFF8EBBE6 /* OCMStubRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMStubRecorder.h; path = Source/OCMock/OCMStubRecorder.h; sourceTree = "<group>"; };
-		601355EC1450EF171590B66154CF584F /* PVGTableViewProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxy.h; sourceTree = "<group>"; };
+		5F8A9A168015EEC1A00990A9F39086FA /* PVGTableViewSectionHeaderViewModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSectionHeaderViewModel.m; sourceTree = "<group>"; };
+		60CB68286AA49CB73A80B4FD04A9F281 /* OCMPassByRefSetter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMPassByRefSetter.m; path = Source/OCMock/OCMPassByRefSetter.m; sourceTree = "<group>"; };
+		6139052683DA9D2919C25A9DAFFDA8B6 /* OCMMacroState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMMacroState.m; path = Source/OCMock/OCMMacroState.m; sourceTree = "<group>"; };
 		6220A21BE212F9D6DC8430F945174A8B /* RACDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDisposable.m; path = ReactiveCocoa/RACDisposable.m; sourceTree = "<group>"; };
 		62C4D4C72D34B1C31A681E14150D5C35 /* UIControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupport.m"; path = "ReactiveCocoa/UIControl+RACSignalSupport.m"; sourceTree = "<group>"; };
+		6363335842B97DE79614E400FB760ADF /* PVGTableViewRenderCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewRenderCommand.m; sourceTree = "<group>"; };
 		645C0AF40ACADF2D65ED38896502C3D8 /* RACSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignal.h; path = ReactiveCocoa/RACSignal.h; sourceTree = "<group>"; };
-		6482D6D6A0A79192D2195C2C8436590C /* OCMInvocationMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationMatcher.h; path = Source/OCMock/OCMInvocationMatcher.h; sourceTree = "<group>"; };
-		64BF94CD950860CCC454E35CAFD22649 /* OCMExceptionReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExceptionReturnValueProvider.h; path = Source/OCMock/OCMExceptionReturnValueProvider.h; sourceTree = "<group>"; };
+		666AE31483568C2B4F8CF3FC24104222 /* OCMArgAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArgAction.h; path = Source/OCMock/OCMArgAction.h; sourceTree = "<group>"; };
+		66B75A71085B82C972E5724BC4B51AAB /* PVGTableViewCellViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCellViewModel.h; sourceTree = "<group>"; };
 		67525045ED955F40E7199959340A76D5 /* NSObject+RACDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACDescription.m"; path = "ReactiveCocoa/NSObject+RACDescription.m"; sourceTree = "<group>"; };
+		675566099AC1EE982389D39471AD4F64 /* OCMInvocationMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationMatcher.m; path = Source/OCMock/OCMInvocationMatcher.m; sourceTree = "<group>"; };
 		68442A0C90D48FC878BCFF5916E7E57F /* RACScopedDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACScopedDisposable.m; path = ReactiveCocoa/RACScopedDisposable.m; sourceTree = "<group>"; };
+		68AA6F48A142721EEF090414F4337756 /* OCObserverMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCObserverMockObject.h; path = Source/OCMock/OCObserverMockObject.h; sourceTree = "<group>"; };
 		69A2B75A66C6D250737F21FE802C8337 /* RACSignal+Operations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACSignal+Operations.h"; path = "ReactiveCocoa/RACSignal+Operations.h"; sourceTree = "<group>"; };
 		6A95FBBA33A0F0F59621803314BCB125 /* NSEnumerator+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSEnumerator+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		6A999A7F538AF8A4862AC71F53E83065 /* UIButton+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+RACCommandSupport.h"; path = "ReactiveCocoa/UIButton+RACCommandSupport.h"; sourceTree = "<group>"; };
 		6C920DF194B4B54D98AB9131ABA53F72 /* RACValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACValueTransformer.m; path = ReactiveCocoa/RACValueTransformer.m; sourceTree = "<group>"; };
-		6CD7398CD3504557EFDF05D5411AF244 /* PVGTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		6CE6A88CE9D0A2AB63F299F0B80F2089 /* RACEvent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEvent.h; path = ReactiveCocoa/RACEvent.h; sourceTree = "<group>"; };
-		6D6972A1269B6913FDD3FFCD0B7CD38A /* OCMock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMock.h; path = Source/OCMock/OCMock.h; sourceTree = "<group>"; };
-		6DA56DE4A59BA51C3F55249BD971FA34 /* NSObject+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+OCMAdditions.m"; path = "Source/OCMock/NSObject+OCMAdditions.m"; sourceTree = "<group>"; };
+		6D84D48E9F6039CC5745C6025B7A2314 /* OCMLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMLocation.h; path = Source/OCMock/OCMLocation.h; sourceTree = "<group>"; };
 		6DC2DB1E35FC7686645F432E2D43EED6 /* RACSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSignal.m; path = ReactiveCocoa/RACSignal.m; sourceTree = "<group>"; };
-		70711C1A6DCDA7C32368789F5B722CAB /* OCMObserverRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMObserverRecorder.h; path = Source/OCMock/OCMObserverRecorder.h; sourceTree = "<group>"; };
 		71060F211137E401843C82AFA05CE091 /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = ReactiveCocoa/RACSerialDisposable.m; sourceTree = "<group>"; };
 		731CB8BBB296456F60B763EC89FD783D /* RACValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACValueTransformer.h; path = ReactiveCocoa/RACValueTransformer.h; sourceTree = "<group>"; };
-		75AD99C4F0AB71CC0E6854E7E8376C29 /* PVGTableViewSectionHeaderViewModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSectionHeaderViewModel.m; sourceTree = "<group>"; };
 		7675D758BEA43B616C22A12872243A2F /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+RACCommandSupport.m"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
 		771971D9207A05ACF42A8AD2E5A83E5F /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptingAssignmentTrampoline.h; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
 		7739114363484F5B99FC942CA441E734 /* UICollectionReusableView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UICollectionReusableView+RACSignalSupport.h"; path = "ReactiveCocoa/UICollectionReusableView+RACSignalSupport.h"; sourceTree = "<group>"; };
@@ -458,85 +460,83 @@
 		7A850C4B949F8C3B3274B2BDC3B699B9 /* RACQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACQueueScheduler.m; path = ReactiveCocoa/RACQueueScheduler.m; sourceTree = "<group>"; };
 		7B453ED2E6C87929577EF64B727FB3B4 /* PVGTableViewProxy.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PVGTableViewProxy.xcconfig; sourceTree = "<group>"; };
 		7B69520299977F607F84A81182091D9A /* NSIndexSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSIndexSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		7B7ED8A1DEE24AF49D10AF61C1FD49DA /* PVGTableViewProxy-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "PVGTableViewProxy-Private.xcconfig"; sourceTree = "<group>"; };
 		7B9F1D7933FB568003EE1D92E69618F0 /* NSObject+RACKVOWrapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACKVOWrapper.m"; path = "ReactiveCocoa/NSObject+RACKVOWrapper.m"; sourceTree = "<group>"; };
 		7D7A7A322B65DACBDA9ED92B41A4B55D /* RACCompoundDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCompoundDisposable.m; path = ReactiveCocoa/RACCompoundDisposable.m; sourceTree = "<group>"; };
 		7D80BD19BCD22037F8B73C012EC4F5DF /* UIBarButtonItem+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIBarButtonItem+RACCommandSupport.h"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h"; sourceTree = "<group>"; };
 		7E56827C637823BFC6CB3031175FD586 /* Pods-ios-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ios-resources.sh"; sourceTree = "<group>"; };
-		81074940930775A6B73C6D5690004993 /* OCMVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMVerifier.h; path = Source/OCMock/OCMVerifier.h; sourceTree = "<group>"; };
-		812BD09CB5847DF05EC987B30116D22E /* OCMRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRecorder.h; path = Source/OCMock/OCMRecorder.h; sourceTree = "<group>"; };
+		80FE5B4C23977BE305C2DE60E73DFE49 /* OCMInvocationStub.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationStub.m; path = Source/OCMock/OCMInvocationStub.m; sourceTree = "<group>"; };
 		815FA3941258787930F9C93FEECE1C70 /* RACTargetQueueScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTargetQueueScheduler.m; path = ReactiveCocoa/RACTargetQueueScheduler.m; sourceTree = "<group>"; };
-		82944A7CA6E952E30D9EEE98CBD38DC5 /* OCMPassByRefSetter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMPassByRefSetter.m; path = Source/OCMock/OCMPassByRefSetter.m; sourceTree = "<group>"; };
 		82EF5CAD58DF6BD48DFAC5FF9D19742D /* RACDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDisposable.h; path = ReactiveCocoa/RACDisposable.h; sourceTree = "<group>"; };
-		84DBCCE329925DD71E14A8D868932804 /* PVGTableViewSimpleDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSimpleDataSource.m; sourceTree = "<group>"; };
-		84FEE6ABBDB5CFFAA5FF5B67E4E5F6A5 /* PVGTableViewRenderCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewRenderCommand.m; sourceTree = "<group>"; };
+		863F844B16AFBDC1B27A5F5CCA809D03 /* OCMNotificationPoster.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMNotificationPoster.m; path = Source/OCMock/OCMNotificationPoster.m; sourceTree = "<group>"; };
+		866B3F7DD199A25179B34AD7445A95B5 /* OCObserverMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCObserverMockObject.m; path = Source/OCMock/OCObserverMockObject.m; sourceTree = "<group>"; };
 		867CB838C815185BD99E6EACB29C66F2 /* UIControl+RACSignalSupportPrivate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIControl+RACSignalSupportPrivate.m"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.m"; sourceTree = "<group>"; };
 		8698798B5EDB069C55026FDAD48DD9FD /* UIActionSheet+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+RACSignalSupport.h"; path = "ReactiveCocoa/UIActionSheet+RACSignalSupport.h"; sourceTree = "<group>"; };
-		88C19BAC90FBBFA3148A7FA3DE2A314E /* OCMLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMLocation.h; path = Source/OCMock/OCMLocation.h; sourceTree = "<group>"; };
+		86A3FAEABDCAA30D2992029959D2DCC7 /* OCMReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMReturnValueProvider.h; path = Source/OCMock/OCMReturnValueProvider.h; sourceTree = "<group>"; };
+		871EDC5A483BBD7E7A4D8C1E86D58B2E /* PVGNoAnimationTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGNoAnimationTableViewProxyAnimator.m; sourceTree = "<group>"; };
 		89F741FB0B205AEE49FBE3B16CE52A46 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A0500FB82C293EB5143F7A158A7246A /* OCMNotificationPoster.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMNotificationPoster.m; path = Source/OCMock/OCMNotificationPoster.m; sourceTree = "<group>"; };
+		8A6B7F917C0A53CEF473232DCB5ABB03 /* PVGNoAnimationTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGNoAnimationTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		8A87C92CD7C84C8B1F6AF29C71D6CC29 /* ReactiveCocoa-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ReactiveCocoa-dummy.m"; sourceTree = "<group>"; };
+		8B8B3E93C84A55ACC3C313B6F3412A85 /* OCMNotificationPoster.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMNotificationPoster.h; path = Source/OCMock/OCMNotificationPoster.h; sourceTree = "<group>"; };
 		8CEDE813274E5575E4CE20ECBF73370E /* RACmetamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACmetamacros.h; path = ReactiveCocoa/extobjc/RACmetamacros.h; sourceTree = "<group>"; };
 		8CF8F5CC10D35B3E8FDAD293BFDAE207 /* RACEXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTRuntimeExtensions.h; path = ReactiveCocoa/extobjc/RACEXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		8D65F669BBA9FD3472182008FD2F56F1 /* OCProtocolMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCProtocolMockObject.h; path = Source/OCMock/OCProtocolMockObject.h; sourceTree = "<group>"; };
-		8D801CB6F835721F575C154D6EC95CDD /* OCMBlockArgCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockArgCaller.h; path = Source/OCMock/OCMBlockArgCaller.h; sourceTree = "<group>"; };
-		8E997CA2B005D958F4D7DEAC7601E626 /* OCMInvocationMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationMatcher.m; path = Source/OCMock/OCMInvocationMatcher.m; sourceTree = "<group>"; };
 		8F8FB48AD6E01B580EB71D5412CA100E /* RACTargetQueueScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTargetQueueScheduler.h; path = ReactiveCocoa/RACTargetQueueScheduler.h; sourceTree = "<group>"; };
 		905F139C1B87E832FBFCA0C499386B14 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
+		90EEFE38D42D289FEF46D7C0F1204E20 /* PVGTableViewSection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSection.h; sourceTree = "<group>"; };
 		91A70A055D199DA59B7AA72048BC6495 /* ReactiveCocoa.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ReactiveCocoa.h; path = ReactiveCocoa/ReactiveCocoa.h; sourceTree = "<group>"; };
 		91B9728F6C900C2D1BF1953CD65AFD9F /* RACUnarySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnarySequence.h; path = ReactiveCocoa/RACUnarySequence.h; sourceTree = "<group>"; };
 		920D7A59A7DAE570F8DAC361EE3B4E7A /* NSObject+RACPropertySubscribing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACPropertySubscribing.m"; path = "ReactiveCocoa/NSObject+RACPropertySubscribing.m"; sourceTree = "<group>"; };
 		922263689244BB247089E56E21317FF1 /* RACSubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubject.h; path = ReactiveCocoa/RACSubject.h; sourceTree = "<group>"; };
 		922CAF6D4FCADB193A65F5421B238F8C /* RACArraySequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACArraySequence.m; path = ReactiveCocoa/RACArraySequence.m; sourceTree = "<group>"; };
 		926ABBD47DCDA26015F4BAB18F6025CF /* RACBacktrace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACBacktrace.h; path = ReactiveCocoa/RACBacktrace.h; sourceTree = "<group>"; };
+		9409E1B756C12FD74525B22D1F2EB7D0 /* PVGGenericTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGGenericTableViewProxyAnimator.h; sourceTree = "<group>"; };
 		94471863AFA368A15D8BCD5ABD0205AB /* RACEmptySignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySignal.h; path = ReactiveCocoa/RACEmptySignal.h; sourceTree = "<group>"; };
+		950974CBF81BB88BCF1C1D032D033E01 /* OCMInvocationExpectation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationExpectation.m; path = Source/OCMock/OCMInvocationExpectation.m; sourceTree = "<group>"; };
+		950A8699AB199E57E60FA5BAEFB8F3FA /* PVGTableViewDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewDataSource.h; sourceTree = "<group>"; };
 		95875C0920F9EC19B8FA7F5A96FA23EE /* RACSignalSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSignalSequence.h; path = ReactiveCocoa/RACSignalSequence.h; sourceTree = "<group>"; };
-		965D4F0182E62F57610C38327B25B11F /* OCMRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRecorder.m; path = Source/OCMock/OCMRecorder.m; sourceTree = "<group>"; };
-		9709C1909E720888C6FC913104CFBADB /* OCMInvocationStub.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMInvocationStub.m; path = Source/OCMock/OCMInvocationStub.m; sourceTree = "<group>"; };
-		9841F05844C39EE6A0DAA2C7657A95B2 /* OCMRealObjectForwarder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRealObjectForwarder.h; path = Source/OCMock/OCMRealObjectForwarder.h; sourceTree = "<group>"; };
-		9986C9CE4CE4D4D9FEA23F793ACECCE2 /* OCObserverMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCObserverMockObject.h; path = Source/OCMock/OCObserverMockObject.h; sourceTree = "<group>"; };
+		95F8544BAAE540790C398B5433590EAD /* OCMFunctionsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctionsPrivate.h; path = Source/OCMock/OCMFunctionsPrivate.h; sourceTree = "<group>"; };
+		968F2F0E14AE27986D11FE379D5E52EA /* PVGGenericTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGGenericTableViewProxyAnimator.m; sourceTree = "<group>"; };
+		98B01105C0B20827F1337B1CA4FFD72B /* OCMVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMVerifier.m; path = Source/OCMock/OCMVerifier.m; sourceTree = "<group>"; };
+		99EAF7C66E7FE027E623E75049423CCB /* PVGTableViewSectionHeader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSectionHeader.h; sourceTree = "<group>"; };
+		9A167B84312F3EE1F413DE70F203D3A2 /* OCMBoxedReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBoxedReturnValueProvider.m; path = Source/OCMock/OCMBoxedReturnValueProvider.m; sourceTree = "<group>"; };
 		9A2F6659A2DCFC1A1AEFDF257CF81F07 /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImagePickerController+RACSignalSupport.m"; path = "ReactiveCocoa/UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
-		9A34D070036E1B8F41CA70BA8BCBFD22 /* PVGTableViewSimpleDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewSimpleDataSource.h; sourceTree = "<group>"; };
 		9BEA2C4A89DF586C1C4B77E2E18587A1 /* RACSignal+Operations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "RACSignal+Operations.m"; path = "ReactiveCocoa/RACSignal+Operations.m"; sourceTree = "<group>"; };
-		9C5228A268F4112752FE411237D0244A /* PVGTableViewScrollCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewScrollCommand.h; sourceTree = "<group>"; };
-		9D2C33F9E87044784262347F653AB066 /* OCMExpectationRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExpectationRecorder.h; path = Source/OCMock/OCMExpectationRecorder.h; sourceTree = "<group>"; };
-		9E298C4F7D8B0502B6A8E0D31EC2E254 /* OCMArgAction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArgAction.m; path = Source/OCMock/OCMArgAction.m; sourceTree = "<group>"; };
-		9F315B7ECB8DBE8AA0997267C1893CF7 /* OCMStubRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMStubRecorder.m; path = Source/OCMock/OCMStubRecorder.m; sourceTree = "<group>"; };
+		9D2EB4318FAE845F8F98927FA40984B6 /* PVGTableViewProxyAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxyAnimator.h; sourceTree = "<group>"; };
+		9DA29883DC280E4C31FB87A9B1A09EF1 /* PVGTableViewProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewProxy.m; sourceTree = "<group>"; };
 		A1B7CF6D5244515DE2329B227B5B6708 /* NSNotificationCenter+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+RACSupport.m"; path = "ReactiveCocoa/NSNotificationCenter+RACSupport.m"; sourceTree = "<group>"; };
 		A29C1F74C5EFC2EEBE6AC31215BF8392 /* RACDynamicSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSequence.m; path = ReactiveCocoa/RACDynamicSequence.m; sourceTree = "<group>"; };
 		A364F4B47B0AD3047B148D67BDAB3564 /* RACReplaySubject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReplaySubject.h; path = ReactiveCocoa/RACReplaySubject.h; sourceTree = "<group>"; };
-		A3D3194E20C34D7BB582FCC9713922A4 /* NSValue+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+OCMAdditions.m"; path = "Source/OCMock/NSValue+OCMAdditions.m"; sourceTree = "<group>"; };
 		A3EB47188B7F17C00AC9015CC2A5AFA3 /* NSOrderedSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSOrderedSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		A43F590B5C69E2876E2A29EA8942D8DB /* libReactiveCocoa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactiveCocoa.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A4D30D704C888A908D6F290E3ED41C9F /* OCMConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMConstraint.h; path = Source/OCMock/OCMConstraint.h; sourceTree = "<group>"; };
 		A598DC9557D3DEF6E8FAEDF22AC94CB3 /* RACKVOChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOChannel.h; path = ReactiveCocoa/RACKVOChannel.h; sourceTree = "<group>"; };
 		A6C5E34582AAE79B79B143134BED9612 /* NSString+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSString+RACSequenceAdditions.h"; sourceTree = "<group>"; };
-		A7456E91F97A5382D9F631815E4B39CA /* OCMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMockObject.m; path = Source/OCMock/OCMockObject.m; sourceTree = "<group>"; };
 		A89A6891E532D68DA63ECC928C450845 /* RACUnit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACUnit.m; path = ReactiveCocoa/RACUnit.m; sourceTree = "<group>"; };
 		A8CC4405DC933D32370924D2AAFCB295 /* UISwitch+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISwitch+RACSignalSupport.m"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.m"; sourceTree = "<group>"; };
-		A90257329F94219C7AB6A66A347CAFD7 /* PVGGenericTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGGenericTableViewProxyAnimator.m; sourceTree = "<group>"; };
-		A930AEF69CE9D9B6F367C60D73D68147 /* OCMFunctionsPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctionsPrivate.h; path = Source/OCMock/OCMFunctionsPrivate.h; sourceTree = "<group>"; };
-		A98E938E27C44F08AFAB6FD2E7728AFD /* OCMArg.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArg.h; path = Source/OCMock/OCMArg.h; sourceTree = "<group>"; };
 		AA64D794ABE0DBEF7C33B192C7A8A923 /* RACReplaySubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReplaySubject.m; path = ReactiveCocoa/RACReplaySubject.m; sourceTree = "<group>"; };
+		AA72986BFF2C41B26A6F4E2C564F638C /* OCClassMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCClassMockObject.h; path = Source/OCMock/OCClassMockObject.h; sourceTree = "<group>"; };
+		AA8F418B207D53C05C4BACA7FE422B1C /* OCMBlockCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockCaller.h; path = Source/OCMock/OCMBlockCaller.h; sourceTree = "<group>"; };
+		AA99F0852C84DE380258D68DC5BCBE63 /* OCMPassByRefSetter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMPassByRefSetter.h; path = Source/OCMock/OCMPassByRefSetter.h; sourceTree = "<group>"; };
 		AAA4D44A335DC832947DC0C39CDEE53E /* RACCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACCommand.m; path = ReactiveCocoa/RACCommand.m; sourceTree = "<group>"; };
 		AB0F51FEC409855C488EF1E6DD4121E7 /* NSSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		ABD3560945B4BCAA3867D74010DA1002 /* RACGroupedSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACGroupedSignal.m; path = ReactiveCocoa/RACGroupedSignal.m; sourceTree = "<group>"; };
-		ACC64AC47544271C1623B23901E41970 /* OCMArg.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArg.m; path = Source/OCMock/OCMArg.m; sourceTree = "<group>"; };
+		ACAC49417FE432461825E75CE151D4BD /* OCMVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMVerifier.h; path = Source/OCMock/OCMVerifier.h; sourceTree = "<group>"; };
 		AD51D875EFE9D59C4C349E11359CA076 /* RACMulticastConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACMulticastConnection.h; path = ReactiveCocoa/RACMulticastConnection.h; sourceTree = "<group>"; };
 		ADFFA519A388AEA9CCB9063946D66E43 /* UIStepper+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIStepper+RACSignalSupport.h"; path = "ReactiveCocoa/UIStepper+RACSignalSupport.h"; sourceTree = "<group>"; };
+		AE524CE6151000ACB3FDE5AA646B3215 /* libOCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AEF1A37504F52691DAA2195D8901F8D4 /* NSOrderedSet+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSOrderedSet+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		AF358DDB6D2837019752100291B34571 /* OCMock.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = OCMock.xcconfig; sourceTree = "<group>"; };
+		B06CD0B34F6DF74A3006A46BD99B58BF /* NSInvocation+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+OCMAdditions.h"; path = "Source/OCMock/NSInvocation+OCMAdditions.h"; sourceTree = "<group>"; };
 		B076AD76C51CAE345ADE64C725E37ED4 /* RACDynamicSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSequence.h; path = ReactiveCocoa/RACDynamicSequence.h; sourceTree = "<group>"; };
+		B16A3715B92A9996BD1FA3A83CC62291 /* OCMIndirectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMIndirectReturnValueProvider.m; path = Source/OCMock/OCMIndirectReturnValueProvider.m; sourceTree = "<group>"; };
 		B1CF46039EA83E404B60E87DF501BBB1 /* UITextField+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITextField+RACSignalSupport.m"; path = "ReactiveCocoa/UITextField+RACSignalSupport.m"; sourceTree = "<group>"; };
 		B2B8CFC154A95428B7ED73537D260054 /* NSString+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+RACSupport.h"; path = "ReactiveCocoa/NSString+RACSupport.h"; sourceTree = "<group>"; };
 		B2F132CAD025A691D7C572642636836E /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
-		B2FF6B6E10B1D2C3A96DE6AD4CF793B2 /* PVGNoAnimationTableViewProxyAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGNoAnimationTableViewProxyAnimator.m; sourceTree = "<group>"; };
-		B32FF4B288316401FCF396C490AADA92 /* OCMBlockCaller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBlockCaller.m; path = Source/OCMock/OCMBlockCaller.m; sourceTree = "<group>"; };
 		B34B0D63A1F7ACE9BCFA8A421B3525D8 /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = ReactiveCocoa/RACStringSequence.m; sourceTree = "<group>"; };
 		B399772008DA02172F1A21DE7CB43214 /* NSFileHandle+RACSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileHandle+RACSupport.h"; path = "ReactiveCocoa/NSFileHandle+RACSupport.h"; sourceTree = "<group>"; };
 		B3B11C192C0B046402E0FAAACBE01FD2 /* RACSerialDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSerialDisposable.h; path = ReactiveCocoa/RACSerialDisposable.h; sourceTree = "<group>"; };
 		B42C5004D70ABC119E7E26F283CC4BDF /* RACImmediateScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACImmediateScheduler.m; path = ReactiveCocoa/RACImmediateScheduler.m; sourceTree = "<group>"; };
 		B56497B2918A5A0E56AAF26D73A4B878 /* RACBlockTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBlockTrampoline.m; path = ReactiveCocoa/RACBlockTrampoline.m; sourceTree = "<group>"; };
-		B6925CFB0BE92594EB794223DF2554B4 /* PVGTableViewSection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewSection.m; sourceTree = "<group>"; };
+		B7EE9DA39CC3F39FC50556E9194144FF /* OCMIndirectReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMIndirectReturnValueProvider.h; path = Source/OCMock/OCMIndirectReturnValueProvider.h; sourceTree = "<group>"; };
 		B7F8AF67FBB1765318FF2D3D17B66CDA /* UISegmentedControl+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UISegmentedControl+RACSignalSupport.m"; path = "ReactiveCocoa/UISegmentedControl+RACSignalSupport.m"; sourceTree = "<group>"; };
 		B84CB9F23C2898D165E3CC7B366710A1 /* UIBarButtonItem+RACCommandSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIBarButtonItem+RACCommandSupport.m"; path = "ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m"; sourceTree = "<group>"; };
 		B9B383D316786CD1F391BDAF26040D91 /* NSObject+RACDeallocating.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+RACDeallocating.h"; path = "ReactiveCocoa/NSObject+RACDeallocating.h"; sourceTree = "<group>"; };
@@ -546,21 +546,22 @@
 		BA97C73028E4F2C19682DC3F5D1F03CA /* UIControl+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupport.h"; path = "ReactiveCocoa/UIControl+RACSignalSupport.h"; sourceTree = "<group>"; };
 		BAF67FEE641CFEF0BE5DCED6535DD8AF /* RACSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubject.m; path = ReactiveCocoa/RACSubject.m; sourceTree = "<group>"; };
 		BD16F5E0F50DC014D5C996225EB8D80B /* Pods-ios-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ios-acknowledgements.markdown"; sourceTree = "<group>"; };
+		BD73C23F7F6D4BE34DA89723C67DC7C3 /* PVGTableViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCell.h; sourceTree = "<group>"; };
 		BE6D87FEFBE34D9E57ACB2CFDF3284A3 /* RACSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSequence.m; path = ReactiveCocoa/RACSequence.m; sourceTree = "<group>"; };
 		C02DD7524C315129FCDD763AC77D048A /* RACDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDelegateProxy.h; path = ReactiveCocoa/RACDelegateProxy.h; sourceTree = "<group>"; };
 		C051B5B2DCB50742A9CE431F104A17FC /* RACChannel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACChannel.h; path = ReactiveCocoa/RACChannel.h; sourceTree = "<group>"; };
+		C12944A489CCADD0DA3DEE596FE1B846 /* OCMInvocationStub.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationStub.h; path = Source/OCMock/OCMInvocationStub.h; sourceTree = "<group>"; };
 		C2C1057DAB64F0DE1BC45963C9E0B3ED /* RACReturnSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACReturnSignal.m; path = ReactiveCocoa/RACReturnSignal.m; sourceTree = "<group>"; };
+		C47003984B71B85C4D2314671004FE51 /* NSObject+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+OCMAdditions.m"; path = "Source/OCMock/NSObject+OCMAdditions.m"; sourceTree = "<group>"; };
 		C55DDA26080B8843460C52F1BA04701C /* RACBehaviorSubject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACBehaviorSubject.m; path = ReactiveCocoa/RACBehaviorSubject.m; sourceTree = "<group>"; };
 		C59D6FB68DDFB619171281D2757B6300 /* RACObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACObjCRuntime.h; path = ReactiveCocoa/RACObjCRuntime.h; sourceTree = "<group>"; };
 		C5B8D17F7061AEB62F9F624A83C4C7F9 /* UIGestureRecognizer+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIGestureRecognizer+RACSignalSupport.h"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h"; sourceTree = "<group>"; };
 		C625CD9258C8B36AF99D5B25F47FEF28 /* RACCompoundDisposable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCompoundDisposable.h; path = ReactiveCocoa/RACCompoundDisposable.h; sourceTree = "<group>"; };
-		C6EF1C2A03766C2E31197D4B012C1506 /* OCMBoxedReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBoxedReturnValueProvider.m; path = Source/OCMock/OCMBoxedReturnValueProvider.m; sourceTree = "<group>"; };
+		C639DEFFB1279B61AA75E54B9E7C25F2 /* OCMLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMLocation.m; path = Source/OCMock/OCMLocation.m; sourceTree = "<group>"; };
+		C6E0802894C26EAB6F0493A7A148697E /* OCMRealObjectForwarder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRealObjectForwarder.m; path = Source/OCMock/OCMRealObjectForwarder.m; sourceTree = "<group>"; };
 		C73F688E5BC94E456D56BC02B1A584D8 /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriptingAssignmentTrampoline.m; path = ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
-		C75433977EE2507B5E0E441F367E3B19 /* OCMock-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "OCMock-Private.xcconfig"; sourceTree = "<group>"; };
 		C7AD4041B478EC9005BF39A02B58A4E3 /* RACSubscriptionScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriptionScheduler.h; path = ReactiveCocoa/RACSubscriptionScheduler.h; sourceTree = "<group>"; };
 		C7CBD7D718CEE3FE4466BF512532C1A3 /* RACEXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEXTKeyPathCoding.h; path = ReactiveCocoa/extobjc/RACEXTKeyPathCoding.h; sourceTree = "<group>"; };
-		C8367006F792E1854698F04C2260A9BD /* OCMNotificationPoster.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMNotificationPoster.h; path = Source/OCMock/OCMNotificationPoster.h; sourceTree = "<group>"; };
-		C8528A5A5D415665F6671E7054AA5E94 /* PVGTableViewCellViewModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCellViewModel.h; sourceTree = "<group>"; };
 		C8770B93A7AAC90292717828E109773D /* RACStream+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACStream+Private.h"; path = "ReactiveCocoa/RACStream+Private.h"; sourceTree = "<group>"; };
 		C89F3E316704C3CEBC72CA450533CF16 /* RACTupleSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTupleSequence.m; path = ReactiveCocoa/RACTupleSequence.m; sourceTree = "<group>"; };
 		C93C5C6C629769B8496CB486461F2961 /* UITableViewHeaderFooterView+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableViewHeaderFooterView+RACSignalSupport.m"; path = "ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m"; sourceTree = "<group>"; };
@@ -568,76 +569,67 @@
 		C9D2E1DCBC47262917BEC8D90EBC5403 /* NSObject+RACLifting.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RACLifting.m"; path = "ReactiveCocoa/NSObject+RACLifting.m"; sourceTree = "<group>"; };
 		C9DE51EDE54C035E8ED69E1D35F5D407 /* RACDynamicSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = ReactiveCocoa/RACDynamicSignal.m; sourceTree = "<group>"; };
 		CA816BF237380D6C013E347D3A95E25F /* RACKVOTrampoline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACKVOTrampoline.h; path = ReactiveCocoa/RACKVOTrampoline.h; sourceTree = "<group>"; };
-		CBE690AA976033A740F0CF81D5958D30 /* OCMBoxedReturnValueProvider.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBoxedReturnValueProvider.h; path = Source/OCMock/OCMBoxedReturnValueProvider.h; sourceTree = "<group>"; };
 		CC49617191AF341E26E453494F00EC3A /* RACTestScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACTestScheduler.h; path = ReactiveCocoa/RACTestScheduler.h; sourceTree = "<group>"; };
-		CD5EFEFAED8BF72C808A31C396D98A2A /* NSMethodSignature+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+OCMAdditions.h"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.h"; sourceTree = "<group>"; };
 		CE54CE749F5963EC960FCA05DCA6CCA1 /* NSDictionary+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSDictionary+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		D0287E25CF8AA4447711D1585B5AD7F4 /* RACSubscriber.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSubscriber.m; path = ReactiveCocoa/RACSubscriber.m; sourceTree = "<group>"; };
+		D028AEDED27B523D16538329374F085C /* OCProtocolMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCProtocolMockObject.h; path = Source/OCMock/OCProtocolMockObject.h; sourceTree = "<group>"; };
 		D094E57D368A25D9785043D14346E254 /* RACUnit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACUnit.h; path = ReactiveCocoa/RACUnit.h; sourceTree = "<group>"; };
 		D0F6E2259805A58291730DE532888E5F /* RACEmptySequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACEmptySequence.h; path = ReactiveCocoa/RACEmptySequence.h; sourceTree = "<group>"; };
-		D1CDC7E4CB9807F50B7C17CEFDE60A91 /* OCMObserverRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMObserverRecorder.m; path = Source/OCMock/OCMObserverRecorder.m; sourceTree = "<group>"; };
-		D3773EA7E2C745D785CCE3C9989467E0 /* OCMInvocationStub.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationStub.h; path = Source/OCMock/OCMInvocationStub.h; sourceTree = "<group>"; };
-		D4B0B1E667C0DBBF9E7F86EBABB8BB89 /* OCPartialMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCPartialMockObject.m; path = Source/OCMock/OCPartialMockObject.m; sourceTree = "<group>"; };
-		D52AD361DC111A395AE0CAA5F64A774B /* PVGTableViewProxy-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PVGTableViewProxy-dummy.m"; sourceTree = "<group>"; };
+		D4822B4DFF40D3E9D959CCBFA9D23102 /* OCMRealObjectForwarder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMRealObjectForwarder.h; path = Source/OCMock/OCMRealObjectForwarder.h; sourceTree = "<group>"; };
 		D53C270F9F3DC9CB1A5B01CE6A9FE6E6 /* UIGestureRecognizer+RACSignalSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIGestureRecognizer+RACSignalSupport.m"; path = "ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m"; sourceTree = "<group>"; };
 		D54D194720BA374E3DC61A6073D013A5 /* UITextField+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextField+RACSignalSupport.h"; path = "ReactiveCocoa/UITextField+RACSignalSupport.h"; sourceTree = "<group>"; };
 		D579BDDB82CF91A14F8A28129A566943 /* RACTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTuple.m; path = ReactiveCocoa/RACTuple.m; sourceTree = "<group>"; };
 		D61A87B9EC03DCFBBE45E9A3DF6EE144 /* NSInvocation+RACTypeParsing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+RACTypeParsing.m"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.m"; sourceTree = "<group>"; };
-		D64B47D5F5E2176CA3C499A15DDB0437 /* NSInvocation+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+OCMAdditions.h"; path = "Source/OCMock/NSInvocation+OCMAdditions.h"; sourceTree = "<group>"; };
 		D7D3076151A27E89C1B7411F17D0A044 /* UISwitch+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISwitch+RACSignalSupport.h"; path = "ReactiveCocoa/UISwitch+RACSignalSupport.h"; sourceTree = "<group>"; };
 		DA324113BB8AB2C2F3051396AA5A388C /* RACEmptySignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEmptySignal.m; path = ReactiveCocoa/RACEmptySignal.m; sourceTree = "<group>"; };
+		DB4BEE5FAF865B4C6D95663C675FDB75 /* OCMInvocationMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMInvocationMatcher.h; path = Source/OCMock/OCMInvocationMatcher.h; sourceTree = "<group>"; };
 		DC6EA08A346B8970E9699719604B50C8 /* RACSubscriber.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACSubscriber.h; path = ReactiveCocoa/RACSubscriber.h; sourceTree = "<group>"; };
-		DCC8E0A51FAF9092C95DCC4E9EB50710 /* PVGTableViewRenderCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewRenderCommand.h; sourceTree = "<group>"; };
 		DE678BD13584DC6861FEDAE08F442AD5 /* RACQueueScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACQueueScheduler+Subclass.h"; path = "ReactiveCocoa/RACQueueScheduler+Subclass.h"; sourceTree = "<group>"; };
-		DF84D9A1151DF5F102F0B1831F926482 /* OCMExceptionReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExceptionReturnValueProvider.m; path = Source/OCMock/OCMExceptionReturnValueProvider.m; sourceTree = "<group>"; };
+		DE89B09BA8C30A80D8B542B608E1891E /* OCMock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMock.h; path = Source/OCMock/OCMock.h; sourceTree = "<group>"; };
 		DFB9413CC21F448276CEFB574A08902A /* NSIndexSet+RACSequenceAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSIndexSet+RACSequenceAdditions.m"; path = "ReactiveCocoa/NSIndexSet+RACSequenceAdditions.m"; sourceTree = "<group>"; };
-		E139E2CBB9802966FF9945BB90A8E0A7 /* OCProtocolMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCProtocolMockObject.m; path = Source/OCMock/OCProtocolMockObject.m; sourceTree = "<group>"; };
 		E1FABCB0E89CAAA52AD258ECAF97C9B9 /* RACIndexSetSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACIndexSetSequence.m; path = ReactiveCocoa/RACIndexSetSequence.m; sourceTree = "<group>"; };
+		E2C11A90E0D113667C3744FDF8BDAC70 /* NSNotificationCenter+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+OCMAdditions.h"; path = "Source/OCMock/NSNotificationCenter+OCMAdditions.h"; sourceTree = "<group>"; };
+		E3C7D0B2B410E8BD185A26272B5544F7 /* OCMock-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "OCMock-Private.xcconfig"; sourceTree = "<group>"; };
 		E4853BC4775668FC24FE5D15A738CB00 /* RACTestScheduler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACTestScheduler.m; path = ReactiveCocoa/RACTestScheduler.m; sourceTree = "<group>"; };
+		E4B2263AD42ADB1CF8E843462E69AA7C /* OCMMacroState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMMacroState.h; path = Source/OCMock/OCMMacroState.h; sourceTree = "<group>"; };
 		E52DFB8D644239658D299590B6B65E12 /* UISlider+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UISlider+RACSignalSupport.h"; path = "ReactiveCocoa/UISlider+RACSignalSupport.h"; sourceTree = "<group>"; };
-		E556193E2AFDAC07ACCD2F548A36A278 /* OCMBlockCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockCaller.h; path = Source/OCMock/OCMBlockCaller.h; sourceTree = "<group>"; };
-		E65544594098B238CB4F2691EE652C07 /* PVGTableViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewCell.h; sourceTree = "<group>"; };
+		E6493A202079E04EA706393D78424CD5 /* OCMArg.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMArg.m; path = Source/OCMock/OCMArg.m; sourceTree = "<group>"; };
 		E65A4F1D0D574E043B87736F9337775C /* RACSignalProvider.d */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.dtrace; name = RACSignalProvider.d; path = ReactiveCocoa/RACSignalProvider.d; sourceTree = "<group>"; };
-		E662F631D7EF7BBD517FFF4EAC5979C5 /* OCClassMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCClassMockObject.m; path = Source/OCMock/OCClassMockObject.m; sourceTree = "<group>"; };
 		E76F89C06792BF0EDC548B2B7A0A7D15 /* NSInvocation+RACTypeParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+RACTypeParsing.h"; path = "ReactiveCocoa/NSInvocation+RACTypeParsing.h"; sourceTree = "<group>"; };
+		E7F354EAD8C9B85C2CFF7DFFAE2F0E3D /* OCMArg.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArg.h; path = Source/OCMock/OCMArg.h; sourceTree = "<group>"; };
 		E8BDBE95107A32FC97E09AB9B81D4867 /* RACCommand.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACCommand.h; path = ReactiveCocoa/RACCommand.h; sourceTree = "<group>"; };
-		E8C546FD95411FB5EE2B8EE722F188AE /* OCMBlockArgCaller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMBlockArgCaller.m; path = Source/OCMock/OCMBlockArgCaller.m; sourceTree = "<group>"; };
 		EA7F48F074150BCC0456D45734DD775C /* UIControl+RACSignalSupportPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIControl+RACSignalSupportPrivate.h"; path = "ReactiveCocoa/UIControl+RACSignalSupportPrivate.h"; sourceTree = "<group>"; };
 		EAE4BB5D11B18A86958894270F4357C8 /* RACEagerSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACEagerSequence.m; path = ReactiveCocoa/RACEagerSequence.m; sourceTree = "<group>"; };
+		EEA20DACB12809F7B9D73DC0CFB4C8AB /* OCMConstraint.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMConstraint.m; path = Source/OCMock/OCMConstraint.m; sourceTree = "<group>"; };
 		EEDF3358CAF10DBB55CAFF88EE7D5F2A /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
-		EF0584A05212CB32368B2EC16951890D /* OCClassMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCClassMockObject.h; path = Source/OCMock/OCClassMockObject.h; sourceTree = "<group>"; };
-		EF330328B5D7D7AC14B3BCCDCEA0F8E8 /* NSValue+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+OCMAdditions.h"; path = "Source/OCMock/NSValue+OCMAdditions.h"; sourceTree = "<group>"; };
-		F1628388550DF248C5F30FF4B27859B9 /* OCMConstraint.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMConstraint.m; path = Source/OCMock/OCMConstraint.m; sourceTree = "<group>"; };
+		EF3A4593437E20CA1D7747C8B7CD7CC1 /* OCMStubRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMStubRecorder.m; path = Source/OCMock/OCMStubRecorder.m; sourceTree = "<group>"; };
+		EFBED41199BA448B71D5B949905C2295 /* OCMBlockArgCaller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMBlockArgCaller.h; path = Source/OCMock/OCMBlockArgCaller.h; sourceTree = "<group>"; };
+		F0453817FB9F7376D8CB00546A335268 /* OCPartialMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCPartialMockObject.h; path = Source/OCMock/OCPartialMockObject.h; sourceTree = "<group>"; };
 		F1C37132F4CD4AED2917B637E30FB7EA /* RACErrorSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACErrorSignal.h; path = ReactiveCocoa/RACErrorSignal.h; sourceTree = "<group>"; };
 		F23D47FC49F17706B3704B858F641474 /* RACDynamicSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACDynamicSignal.h; path = ReactiveCocoa/RACDynamicSignal.h; sourceTree = "<group>"; };
-		F262D391B5F1EECE3493A5FB99E23DEC /* NSMethodSignature+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+OCMAdditions.m"; path = "Source/OCMock/NSMethodSignature+OCMAdditions.m"; sourceTree = "<group>"; };
+		F266271867DBDB9D204D0D625A94000D /* OCMockObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMockObject.h; path = Source/OCMock/OCMockObject.h; sourceTree = "<group>"; };
 		F28C851A91A9877DB8589C7770E48B37 /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+RACCommandSupport.h"; path = "ReactiveCocoa/UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
 		F3E5702AC9C4052BEB95C01C7BC40DC4 /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = ReactiveCocoa/RACImmediateScheduler.h; sourceTree = "<group>"; };
 		F56B8A7DF844C30E726C00CDAF2CF109 /* Pods-ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ios-dummy.m"; sourceTree = "<group>"; };
-		F5B03E8D8A70ACB7797E40270085A07B /* OCMReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMReturnValueProvider.m; path = Source/OCMock/OCMReturnValueProvider.m; sourceTree = "<group>"; };
 		F6589A44A1689815B788906281BD2858 /* UIAlertView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+RACSignalSupport.h"; path = "ReactiveCocoa/UIAlertView+RACSignalSupport.h"; sourceTree = "<group>"; };
-		F7783DDB52C7D34D61CBE52B2782B867 /* PVGTableViewScrollCommand.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PVGTableViewScrollCommand.m; sourceTree = "<group>"; };
+		F73AC6A44543CA993B9EA8250376F4D5 /* PVGTableViewProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PVGTableViewProxy.h; sourceTree = "<group>"; };
+		F832602DA9932B51DF3EB2A38987A4E9 /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Source/OCMock/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
 		F91969A1411FBC6A820CE85A9AE98B06 /* Pods-ios-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ios-acknowledgements.plist"; sourceTree = "<group>"; };
 		F942752256CBB49E0E90309B9E68FDD4 /* RACReturnSignal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACReturnSignal.h; path = ReactiveCocoa/RACReturnSignal.h; sourceTree = "<group>"; };
 		F9668BCC293FA91F76BBB9D9BD5B17E3 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+RACSequenceAdditions.h"; path = "ReactiveCocoa/NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
+		F96FDA238E756CC92965396035488E99 /* OCMExceptionReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMExceptionReturnValueProvider.m; path = Source/OCMock/OCMExceptionReturnValueProvider.m; sourceTree = "<group>"; };
+		F9DC4BFDE58242C6ECB77EBA04F42F13 /* OCMObserverRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMObserverRecorder.m; path = Source/OCMock/OCMObserverRecorder.m; sourceTree = "<group>"; };
 		FAE5389A3D9012ECE4F4433B88D4FAB8 /* RACObjCRuntime.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACObjCRuntime.m; path = ReactiveCocoa/RACObjCRuntime.m; sourceTree = "<group>"; };
 		FBECF5ECA4DFEDFB2FB49F3FA8B676D2 /* NSURLConnection+RACSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLConnection+RACSupport.m"; path = "ReactiveCocoa/NSURLConnection+RACSupport.m"; sourceTree = "<group>"; };
 		FC042EB387C07EB55D8EAAEBFC2ED404 /* RACScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACScheduler.h; path = ReactiveCocoa/RACScheduler.h; sourceTree = "<group>"; };
-		FCFFB082D20FD540A8432470FE0FD0A0 /* libPVGTableViewProxy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPVGTableViewProxy.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD795880489EECB79036A42CA7491636 /* UITextView+RACSignalSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITextView+RACSignalSupport.h"; path = "ReactiveCocoa/UITextView+RACSignalSupport.h"; sourceTree = "<group>"; };
+		FD9419A0B9044AA266828FE0B621E8D0 /* OCMExpectationRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMExpectationRecorder.h; path = Source/OCMock/OCMExpectationRecorder.h; sourceTree = "<group>"; };
+		FE4F2BC66481B9EDAB216C8BA440EDFC /* libPVGTableViewProxy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPVGTableViewProxy.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEA38B00DA2B8C6F7E504DC1760993A8 /* RACStream.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACStream.h; path = ReactiveCocoa/RACStream.h; sourceTree = "<group>"; };
 		FF9300518235D238F740EF249EABF447 /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = ReactiveCocoa/RACKVOChannel.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		02E08C3B6B41FA00DFD940E217C06940 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F7EAAF9E990F2AA9EC014FC801F1EAC9 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		1CD8E159C9928E13247597BA7D224729 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -646,11 +638,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		276946C88320922FBDB5CF2473F9B5DD /* Frameworks */ = {
+		510C22C2EBEECA2F3A979BAB0126CF8D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E0A68F95CBEAE556A41299F87E5A075D /* Foundation.framework in Frameworks */,
+				5CF9424606613D1BED57E588D5DCAACE /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		991C652C4742DD7D945A90F3EFE3A898 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3614656F7B4CA8630B66366932138D4D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -669,8 +669,8 @@
 			isa = PBXGroup;
 			children = (
 				7B453ED2E6C87929577EF64B727FB3B4 /* PVGTableViewProxy.xcconfig */,
-				7B7ED8A1DEE24AF49D10AF61C1FD49DA /* PVGTableViewProxy-Private.xcconfig */,
-				D52AD361DC111A395AE0CAA5F64A774B /* PVGTableViewProxy-dummy.m */,
+				24B0F3D2E21AAEC48B2FC12808AF2DC7 /* PVGTableViewProxy-Private.xcconfig */,
+				46D72EE4289533EBC86E41CCA64F10BA /* PVGTableViewProxy-dummy.m */,
 				5ECC43BD36BA05CE80622EF6CE10828C /* PVGTableViewProxy-prefix.pch */,
 			);
 			name = "Support Files";
@@ -741,74 +741,74 @@
 		7966D46B8417233B90F0CC4DDE9FA9DB /* OCMock */ = {
 			isa = PBXGroup;
 			children = (
-				D64B47D5F5E2176CA3C499A15DDB0437 /* NSInvocation+OCMAdditions.h */,
-				1262D6ACE7E257C1CCF4C830B282F1A3 /* NSInvocation+OCMAdditions.m */,
-				CD5EFEFAED8BF72C808A31C396D98A2A /* NSMethodSignature+OCMAdditions.h */,
-				F262D391B5F1EECE3493A5FB99E23DEC /* NSMethodSignature+OCMAdditions.m */,
-				20C6E7A44A84C5BB5EFA32CC3F514288 /* NSNotificationCenter+OCMAdditions.h */,
-				318C4F9E950AAE22319EFA25180621FD /* NSNotificationCenter+OCMAdditions.m */,
-				075E727F4BA143EC4358DAB6C5B5778A /* NSObject+OCMAdditions.h */,
-				6DA56DE4A59BA51C3F55249BD971FA34 /* NSObject+OCMAdditions.m */,
-				EF330328B5D7D7AC14B3BCCDCEA0F8E8 /* NSValue+OCMAdditions.h */,
-				A3D3194E20C34D7BB582FCC9713922A4 /* NSValue+OCMAdditions.m */,
-				EF0584A05212CB32368B2EC16951890D /* OCClassMockObject.h */,
-				E662F631D7EF7BBD517FFF4EAC5979C5 /* OCClassMockObject.m */,
-				A98E938E27C44F08AFAB6FD2E7728AFD /* OCMArg.h */,
-				ACC64AC47544271C1623B23901E41970 /* OCMArg.m */,
-				58C91BFC78E6400DB7A70EC0B4835702 /* OCMArgAction.h */,
-				9E298C4F7D8B0502B6A8E0D31EC2E254 /* OCMArgAction.m */,
-				8D801CB6F835721F575C154D6EC95CDD /* OCMBlockArgCaller.h */,
-				E8C546FD95411FB5EE2B8EE722F188AE /* OCMBlockArgCaller.m */,
-				E556193E2AFDAC07ACCD2F548A36A278 /* OCMBlockCaller.h */,
-				B32FF4B288316401FCF396C490AADA92 /* OCMBlockCaller.m */,
-				CBE690AA976033A740F0CF81D5958D30 /* OCMBoxedReturnValueProvider.h */,
-				C6EF1C2A03766C2E31197D4B012C1506 /* OCMBoxedReturnValueProvider.m */,
-				13936049D59FA813E22D3A74A5F7B2CE /* OCMConstraint.h */,
-				F1628388550DF248C5F30FF4B27859B9 /* OCMConstraint.m */,
-				64BF94CD950860CCC454E35CAFD22649 /* OCMExceptionReturnValueProvider.h */,
-				DF84D9A1151DF5F102F0B1831F926482 /* OCMExceptionReturnValueProvider.m */,
-				9D2C33F9E87044784262347F653AB066 /* OCMExpectationRecorder.h */,
-				42FD7E848AABCAF8C97EF727DD712BD7 /* OCMExpectationRecorder.m */,
-				37680914889200B2B9050743215DBBCB /* OCMFunctions.h */,
-				267D34AA96EA417369DCD7169B5AFABD /* OCMFunctions.m */,
-				A930AEF69CE9D9B6F367C60D73D68147 /* OCMFunctionsPrivate.h */,
-				1D16047A95DE7C3702EFD0FD59FDDD24 /* OCMIndirectReturnValueProvider.h */,
-				53177876B15AB525D8E50007F07A9B06 /* OCMIndirectReturnValueProvider.m */,
-				0A02DEB7B1079A6DA19D9629371D97EB /* OCMInvocationExpectation.h */,
-				556FD396E58E585893DFCDDFCE252104 /* OCMInvocationExpectation.m */,
-				6482D6D6A0A79192D2195C2C8436590C /* OCMInvocationMatcher.h */,
-				8E997CA2B005D958F4D7DEAC7601E626 /* OCMInvocationMatcher.m */,
-				D3773EA7E2C745D785CCE3C9989467E0 /* OCMInvocationStub.h */,
-				9709C1909E720888C6FC913104CFBADB /* OCMInvocationStub.m */,
-				88C19BAC90FBBFA3148A7FA3DE2A314E /* OCMLocation.h */,
-				54B57ED46B3FDA862365AB20071D5E3C /* OCMLocation.m */,
-				2D24B57B03698B0CAA4366140998FAC0 /* OCMMacroState.h */,
-				46D48BDC8A8AB37DCD86A40A66E88ED3 /* OCMMacroState.m */,
-				C8367006F792E1854698F04C2260A9BD /* OCMNotificationPoster.h */,
-				8A0500FB82C293EB5143F7A158A7246A /* OCMNotificationPoster.m */,
-				70711C1A6DCDA7C32368789F5B722CAB /* OCMObserverRecorder.h */,
-				D1CDC7E4CB9807F50B7C17CEFDE60A91 /* OCMObserverRecorder.m */,
-				4FADAACFC4CB488D7021A0E795B11177 /* OCMPassByRefSetter.h */,
-				82944A7CA6E952E30D9EEE98CBD38DC5 /* OCMPassByRefSetter.m */,
-				9841F05844C39EE6A0DAA2C7657A95B2 /* OCMRealObjectForwarder.h */,
-				06B2C4C53B4320316B5F030A895E7BF3 /* OCMRealObjectForwarder.m */,
-				812BD09CB5847DF05EC987B30116D22E /* OCMRecorder.h */,
-				965D4F0182E62F57610C38327B25B11F /* OCMRecorder.m */,
-				0D95B7E1C217581D6C85FE670C44C75B /* OCMReturnValueProvider.h */,
-				F5B03E8D8A70ACB7797E40270085A07B /* OCMReturnValueProvider.m */,
-				5FB8D2684FC592CC91B5AA4FFF8EBBE6 /* OCMStubRecorder.h */,
-				9F315B7ECB8DBE8AA0997267C1893CF7 /* OCMStubRecorder.m */,
-				81074940930775A6B73C6D5690004993 /* OCMVerifier.h */,
-				49F83A0E46824B501A3B42347E730DDF /* OCMVerifier.m */,
-				6D6972A1269B6913FDD3FFCD0B7CD38A /* OCMock.h */,
-				585496D12D02F30012532E923DEBB9C7 /* OCMockObject.h */,
-				A7456E91F97A5382D9F631815E4B39CA /* OCMockObject.m */,
-				9986C9CE4CE4D4D9FEA23F793ACECCE2 /* OCObserverMockObject.h */,
-				2DFBCAF48652DA9A0D7C2025A6D68F56 /* OCObserverMockObject.m */,
-				528D81DEB3C59A9C603DFF8C83248E0C /* OCPartialMockObject.h */,
-				D4B0B1E667C0DBBF9E7F86EBABB8BB89 /* OCPartialMockObject.m */,
-				8D65F669BBA9FD3472182008FD2F56F1 /* OCProtocolMockObject.h */,
-				E139E2CBB9802966FF9945BB90A8E0A7 /* OCProtocolMockObject.m */,
+				B06CD0B34F6DF74A3006A46BD99B58BF /* NSInvocation+OCMAdditions.h */,
+				F832602DA9932B51DF3EB2A38987A4E9 /* NSInvocation+OCMAdditions.m */,
+				5491F3B745DC7EF11078528A4268C66B /* NSMethodSignature+OCMAdditions.h */,
+				03AF99200098BCAE2F4DCB6E0E9DF918 /* NSMethodSignature+OCMAdditions.m */,
+				E2C11A90E0D113667C3744FDF8BDAC70 /* NSNotificationCenter+OCMAdditions.h */,
+				016E13D0CE839315F2AABF99DC2DE7B0 /* NSNotificationCenter+OCMAdditions.m */,
+				360B8725437C04A8EF0BC57F9D428C41 /* NSObject+OCMAdditions.h */,
+				C47003984B71B85C4D2314671004FE51 /* NSObject+OCMAdditions.m */,
+				33EC5254D8A1582F80B3E60B4395D9FD /* NSValue+OCMAdditions.h */,
+				0D7FD8FA1E348598C720747E570634A6 /* NSValue+OCMAdditions.m */,
+				AA72986BFF2C41B26A6F4E2C564F638C /* OCClassMockObject.h */,
+				00368C2B27F8B758D3EE22FBEA8E3298 /* OCClassMockObject.m */,
+				E7F354EAD8C9B85C2CFF7DFFAE2F0E3D /* OCMArg.h */,
+				E6493A202079E04EA706393D78424CD5 /* OCMArg.m */,
+				666AE31483568C2B4F8CF3FC24104222 /* OCMArgAction.h */,
+				1D89D360A67C35D7C01465F95D4BF29D /* OCMArgAction.m */,
+				EFBED41199BA448B71D5B949905C2295 /* OCMBlockArgCaller.h */,
+				48A6541559C7DADE343D7A70D973391A /* OCMBlockArgCaller.m */,
+				AA8F418B207D53C05C4BACA7FE422B1C /* OCMBlockCaller.h */,
+				2CAC2E2BC839F97F9A4151270755DA02 /* OCMBlockCaller.m */,
+				345967331A372F93EFA1890814C86068 /* OCMBoxedReturnValueProvider.h */,
+				9A167B84312F3EE1F413DE70F203D3A2 /* OCMBoxedReturnValueProvider.m */,
+				A4D30D704C888A908D6F290E3ED41C9F /* OCMConstraint.h */,
+				EEA20DACB12809F7B9D73DC0CFB4C8AB /* OCMConstraint.m */,
+				4D4D07ADA801539F0A42A6081DA662D8 /* OCMExceptionReturnValueProvider.h */,
+				F96FDA238E756CC92965396035488E99 /* OCMExceptionReturnValueProvider.m */,
+				FD9419A0B9044AA266828FE0B621E8D0 /* OCMExpectationRecorder.h */,
+				2299EEA967B0DD3636A96411075A2D00 /* OCMExpectationRecorder.m */,
+				5B32918FD0D459981A25930AD07F6B52 /* OCMFunctions.h */,
+				16861A8DFD9A3E101C6A8E99E8D93E2D /* OCMFunctions.m */,
+				95F8544BAAE540790C398B5433590EAD /* OCMFunctionsPrivate.h */,
+				B7EE9DA39CC3F39FC50556E9194144FF /* OCMIndirectReturnValueProvider.h */,
+				B16A3715B92A9996BD1FA3A83CC62291 /* OCMIndirectReturnValueProvider.m */,
+				26EB63963AB04C503AA348BA83CC02A0 /* OCMInvocationExpectation.h */,
+				950974CBF81BB88BCF1C1D032D033E01 /* OCMInvocationExpectation.m */,
+				DB4BEE5FAF865B4C6D95663C675FDB75 /* OCMInvocationMatcher.h */,
+				675566099AC1EE982389D39471AD4F64 /* OCMInvocationMatcher.m */,
+				C12944A489CCADD0DA3DEE596FE1B846 /* OCMInvocationStub.h */,
+				80FE5B4C23977BE305C2DE60E73DFE49 /* OCMInvocationStub.m */,
+				6D84D48E9F6039CC5745C6025B7A2314 /* OCMLocation.h */,
+				C639DEFFB1279B61AA75E54B9E7C25F2 /* OCMLocation.m */,
+				E4B2263AD42ADB1CF8E843462E69AA7C /* OCMMacroState.h */,
+				6139052683DA9D2919C25A9DAFFDA8B6 /* OCMMacroState.m */,
+				8B8B3E93C84A55ACC3C313B6F3412A85 /* OCMNotificationPoster.h */,
+				863F844B16AFBDC1B27A5F5CCA809D03 /* OCMNotificationPoster.m */,
+				4D4EE0C6D45024778A4070BE5B352D51 /* OCMObserverRecorder.h */,
+				F9DC4BFDE58242C6ECB77EBA04F42F13 /* OCMObserverRecorder.m */,
+				AA99F0852C84DE380258D68DC5BCBE63 /* OCMPassByRefSetter.h */,
+				60CB68286AA49CB73A80B4FD04A9F281 /* OCMPassByRefSetter.m */,
+				D4822B4DFF40D3E9D959CCBFA9D23102 /* OCMRealObjectForwarder.h */,
+				C6E0802894C26EAB6F0493A7A148697E /* OCMRealObjectForwarder.m */,
+				58B4FD0E9B34B7F88A595BC9495176E6 /* OCMRecorder.h */,
+				00759EFCBBF0E79AD01414A9B9EC4EF6 /* OCMRecorder.m */,
+				86A3FAEABDCAA30D2992029959D2DCC7 /* OCMReturnValueProvider.h */,
+				1CDC021235F135AC19120DE041ED3954 /* OCMReturnValueProvider.m */,
+				3D27096DDEEDC45EA2F21232B4D3A8EC /* OCMStubRecorder.h */,
+				EF3A4593437E20CA1D7747C8B7CD7CC1 /* OCMStubRecorder.m */,
+				ACAC49417FE432461825E75CE151D4BD /* OCMVerifier.h */,
+				98B01105C0B20827F1337B1CA4FFD72B /* OCMVerifier.m */,
+				DE89B09BA8C30A80D8B542B608E1891E /* OCMock.h */,
+				F266271867DBDB9D204D0D625A94000D /* OCMockObject.h */,
+				5465C01CB9D4D3ECB7AE33E1DF2B8BC5 /* OCMockObject.m */,
+				68AA6F48A142721EEF090414F4337756 /* OCObserverMockObject.h */,
+				866B3F7DD199A25179B34AD7445A95B5 /* OCObserverMockObject.m */,
+				F0453817FB9F7376D8CB00546A335268 /* OCPartialMockObject.h */,
+				3F0610842A13AFB6055709F664887F45 /* OCPartialMockObject.m */,
+				D028AEDED27B523D16538329374F085C /* OCProtocolMockObject.h */,
+				16570164A52BE2E3DD5CB6572A35573F /* OCProtocolMockObject.m */,
 				83C52161B32A9B70CC7493015DA8D978 /* Support Files */,
 			);
 			path = OCMock;
@@ -985,8 +985,8 @@
 			isa = PBXGroup;
 			children = (
 				AF358DDB6D2837019752100291B34571 /* OCMock.xcconfig */,
-				C75433977EE2507B5E0E441F367E3B19 /* OCMock-Private.xcconfig */,
-				47B7272403ACA6E3D6558E4A7BE31D17 /* OCMock-dummy.m */,
+				E3C7D0B2B410E8BD185A26272B5544F7 /* OCMock-Private.xcconfig */,
+				0C5EBA91D80CD3C5ED58686DD7C7E299 /* OCMock-dummy.m */,
 				3CF88006BAB6F984CFD4CCDA2EA4430A /* OCMock-prefix.pch */,
 			);
 			name = "Support Files";
@@ -1030,27 +1030,27 @@
 		CBBA83A95C32E29DDEBCAC6491652A61 /* PVGTableViewProxy */ = {
 			isa = PBXGroup;
 			children = (
-				12A364438861FE1676109C76086F1708 /* PVGGenericTableViewProxyAnimator.h */,
-				A90257329F94219C7AB6A66A347CAFD7 /* PVGGenericTableViewProxyAnimator.m */,
-				2CCFA7CE9502200FC46AA40B69BC92F3 /* PVGNoAnimationTableViewProxyAnimator.h */,
-				B2FF6B6E10B1D2C3A96DE6AD4CF793B2 /* PVGNoAnimationTableViewProxyAnimator.m */,
-				E65544594098B238CB4F2691EE652C07 /* PVGTableViewCell.h */,
-				C8528A5A5D415665F6671E7054AA5E94 /* PVGTableViewCellViewModel.h */,
-				33DEA5BA89EAF43034EC22A9F95F179B /* PVGTableViewDataSource.h */,
-				601355EC1450EF171590B66154CF584F /* PVGTableViewProxy.h */,
-				24065F76C971BAEC0F862B117576BE69 /* PVGTableViewProxy.m */,
-				6CD7398CD3504557EFDF05D5411AF244 /* PVGTableViewProxyAnimator.h */,
-				DCC8E0A51FAF9092C95DCC4E9EB50710 /* PVGTableViewRenderCommand.h */,
-				84FEE6ABBDB5CFFAA5FF5B67E4E5F6A5 /* PVGTableViewRenderCommand.m */,
-				9C5228A268F4112752FE411237D0244A /* PVGTableViewScrollCommand.h */,
-				F7783DDB52C7D34D61CBE52B2782B867 /* PVGTableViewScrollCommand.m */,
-				3023AC99DF52D11654C7AEBCB8EB6BD4 /* PVGTableViewSection.h */,
-				B6925CFB0BE92594EB794223DF2554B4 /* PVGTableViewSection.m */,
-				23B65E4F1CE0B9C9C673AA890B09CAC6 /* PVGTableViewSectionHeader.h */,
-				4C8C7366D1C9E2044EC9EAAA51DF743D /* PVGTableViewSectionHeaderViewModel.h */,
-				75AD99C4F0AB71CC0E6854E7E8376C29 /* PVGTableViewSectionHeaderViewModel.m */,
-				9A34D070036E1B8F41CA70BA8BCBFD22 /* PVGTableViewSimpleDataSource.h */,
-				84DBCCE329925DD71E14A8D868932804 /* PVGTableViewSimpleDataSource.m */,
+				9409E1B756C12FD74525B22D1F2EB7D0 /* PVGGenericTableViewProxyAnimator.h */,
+				968F2F0E14AE27986D11FE379D5E52EA /* PVGGenericTableViewProxyAnimator.m */,
+				8A6B7F917C0A53CEF473232DCB5ABB03 /* PVGNoAnimationTableViewProxyAnimator.h */,
+				871EDC5A483BBD7E7A4D8C1E86D58B2E /* PVGNoAnimationTableViewProxyAnimator.m */,
+				BD73C23F7F6D4BE34DA89723C67DC7C3 /* PVGTableViewCell.h */,
+				66B75A71085B82C972E5724BC4B51AAB /* PVGTableViewCellViewModel.h */,
+				950A8699AB199E57E60FA5BAEFB8F3FA /* PVGTableViewDataSource.h */,
+				F73AC6A44543CA993B9EA8250376F4D5 /* PVGTableViewProxy.h */,
+				9DA29883DC280E4C31FB87A9B1A09EF1 /* PVGTableViewProxy.m */,
+				9D2EB4318FAE845F8F98927FA40984B6 /* PVGTableViewProxyAnimator.h */,
+				00779B7557C38374810DC1E9A2585C4C /* PVGTableViewRenderCommand.h */,
+				6363335842B97DE79614E400FB760ADF /* PVGTableViewRenderCommand.m */,
+				3DE12809B21B09380C7106A8C88C00BD /* PVGTableViewScrollCommand.h */,
+				0E8C057A956252EDCFDD209C63B6F531 /* PVGTableViewScrollCommand.m */,
+				90EEFE38D42D289FEF46D7C0F1204E20 /* PVGTableViewSection.h */,
+				0151C01A1729858C7D66FB916EDA17B9 /* PVGTableViewSection.m */,
+				99EAF7C66E7FE027E623E75049423CCB /* PVGTableViewSectionHeader.h */,
+				02165B7C6E85359D228DC1197023E0E2 /* PVGTableViewSectionHeaderViewModel.h */,
+				5F8A9A168015EEC1A00990A9F39086FA /* PVGTableViewSectionHeaderViewModel.m */,
+				2F394E0BD3AAAF4525C8D266BC815259 /* PVGTableViewSimpleDataSource.h */,
+				36A5248683C4E55F6204D49CC45449AD /* PVGTableViewSimpleDataSource.m */,
 			);
 			path = PVGTableViewProxy;
 			sourceTree = "<group>";
@@ -1058,8 +1058,8 @@
 		CCA510CFBEA2D207524CDA0D73C3B561 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				3CD190E1B287D46CB8B84BA505D3D283 /* libOCMock.a */,
-				FCFFB082D20FD540A8432470FE0FD0A0 /* libPVGTableViewProxy.a */,
+				AE524CE6151000ACB3FDE5AA646B3215 /* libOCMock.a */,
+				FE4F2BC66481B9EDAB216C8BA440EDFC /* libPVGTableViewProxy.a */,
 				89F741FB0B205AEE49FBE3B16CE52A46 /* libPods-ios.a */,
 				A43F590B5C69E2876E2A29EA8942D8DB /* libReactiveCocoa.a */,
 			);
@@ -1221,65 +1221,65 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1D8565E5271018890A9817F4BEABEADB /* Headers */ = {
+		57DABD14C73C536B7840E9005E4C9A3A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2D56B281D8E098372CE013D80A911B6 /* NSInvocation+OCMAdditions.h in Headers */,
-				8AF64E66191140A9338FF4162A2E58FE /* NSMethodSignature+OCMAdditions.h in Headers */,
-				CE296C0D6BEAEFF6704155BC4347632A /* NSNotificationCenter+OCMAdditions.h in Headers */,
-				CD4D9F108A8D8F9C927CBCEEBC6BA03C /* NSObject+OCMAdditions.h in Headers */,
-				4146DBDB1C52DD19E299B56460D4B053 /* NSValue+OCMAdditions.h in Headers */,
-				1C10C4029DB6812B1A460F8B79279BE1 /* OCClassMockObject.h in Headers */,
-				7D0BDA951CE5660800EE1F5A9460D392 /* OCMArg.h in Headers */,
-				22D04FC586D6001B4971798DE53B6125 /* OCMArgAction.h in Headers */,
-				FA04865910A96462123E0A1AA2841B59 /* OCMBlockArgCaller.h in Headers */,
-				4B3F42338DABA69A3C11BEE64A8EE191 /* OCMBlockCaller.h in Headers */,
-				BDEE812047CA92E098F4791BCDC2EBD0 /* OCMBoxedReturnValueProvider.h in Headers */,
-				CE0A4ED8BF97F70D4A07497C06C03D48 /* OCMConstraint.h in Headers */,
-				5AD1722490CD393DB93DFA9DBCCFB5DA /* OCMExceptionReturnValueProvider.h in Headers */,
-				0EC22281B28D68450280E577BDD63685 /* OCMExpectationRecorder.h in Headers */,
-				59786D5ABD8B842575EFB9C6C7AE0009 /* OCMFunctions.h in Headers */,
-				7B02A58B25827D0A2F5369BC5E32A455 /* OCMFunctionsPrivate.h in Headers */,
-				A71D39E10990CF2FA8B7BBBB16BA673E /* OCMIndirectReturnValueProvider.h in Headers */,
-				C5850D974F80C184310CF82C1E0CBB52 /* OCMInvocationExpectation.h in Headers */,
-				191FC840B439C66D6B923D06CDB2CDB4 /* OCMInvocationMatcher.h in Headers */,
-				B591936F20279EF4FF288F2A79918A9A /* OCMInvocationStub.h in Headers */,
-				DD1BDDB93C75C4A0B53D43C71FC5C47B /* OCMLocation.h in Headers */,
-				99077B4E6A9CE06E9163E6E83A279B34 /* OCMMacroState.h in Headers */,
-				F96A07C71960FA80D4A9EB055F8ACA1B /* OCMNotificationPoster.h in Headers */,
-				FDF012024867FABF75599D896FCA21B5 /* OCMObserverRecorder.h in Headers */,
-				82213D7AAB77109EFE59A3851BDCE6F8 /* OCMPassByRefSetter.h in Headers */,
-				200106845861E197C8593BFCDCA48961 /* OCMRealObjectForwarder.h in Headers */,
-				9C3BDF068978892F2FA8AFE3A4F831D8 /* OCMRecorder.h in Headers */,
-				37C67244DA139093DCB27A8C081E08B1 /* OCMReturnValueProvider.h in Headers */,
-				9A05080A3E73A35B0A0ADEBC8BD30127 /* OCMStubRecorder.h in Headers */,
-				F4A95524991B6F867A151AFBF23B12AB /* OCMVerifier.h in Headers */,
-				665D6D5C55F7E8C1E32B5A1485237FF1 /* OCMock.h in Headers */,
-				E3A719B4F051A421FA752E0F4B2C1550 /* OCMockObject.h in Headers */,
-				033491472A99EAF93018C8547804624A /* OCObserverMockObject.h in Headers */,
-				F4DDA686AB64DC7F88DCC269FA6D4E23 /* OCPartialMockObject.h in Headers */,
-				13606C2F2D5E0572F8B7616C821B65A1 /* OCProtocolMockObject.h in Headers */,
+				91ADE1263D1167A1E3C5B77AA8D616C6 /* PVGGenericTableViewProxyAnimator.h in Headers */,
+				ACC6E4C4C60CFE44281D246E47BECDAD /* PVGNoAnimationTableViewProxyAnimator.h in Headers */,
+				10BFB7976429D7FE1CF9547B0F347E00 /* PVGTableViewCell.h in Headers */,
+				FB1C69B2D6859BBB036B9978D315F8B5 /* PVGTableViewCellViewModel.h in Headers */,
+				D65A4C4D755682367D4319CC0D96D4D2 /* PVGTableViewDataSource.h in Headers */,
+				0ECE4D58CC0EFD1C1446E887B769A26F /* PVGTableViewProxy.h in Headers */,
+				97DA6B92BA7237C037CEDC3458AE3CBF /* PVGTableViewProxyAnimator.h in Headers */,
+				653CB12B2C3C95DEFAB58CCB9B636C46 /* PVGTableViewRenderCommand.h in Headers */,
+				1D30E3D7A0A454ADD17A6EBD298FAF01 /* PVGTableViewScrollCommand.h in Headers */,
+				5AE25C0EFE636068F51A96D2BA19BD27 /* PVGTableViewSection.h in Headers */,
+				0AF94951F8F49A9A121FE89ECB78CA7C /* PVGTableViewSectionHeader.h in Headers */,
+				EFB603A1676333FE995E02665FD4C7FB /* PVGTableViewSectionHeaderViewModel.h in Headers */,
+				E0A783AB1B7C425228D8C066D97037C7 /* PVGTableViewSimpleDataSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		695FFD61CA64F4FB0D32301DC88FBA73 /* Headers */ = {
+		8A2BEAA4BD7BC6595E4A739298C62BE7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E91E61A5D774A1941B0396D8DE1C3F1C /* PVGGenericTableViewProxyAnimator.h in Headers */,
-				EC5CE6E3D0C87865BE25B6F70AAB2AE4 /* PVGNoAnimationTableViewProxyAnimator.h in Headers */,
-				CDA4C0B55F3494BC0544336E6D49A5AB /* PVGTableViewCell.h in Headers */,
-				1ADE37165A48253AF9381C1FE2F6C983 /* PVGTableViewCellViewModel.h in Headers */,
-				89325843727E6895B657CC7990691122 /* PVGTableViewDataSource.h in Headers */,
-				957587EA75D100E405C88FED19727AB0 /* PVGTableViewProxy.h in Headers */,
-				FE0A205BED60AAF3444F27B8A5B2A375 /* PVGTableViewProxyAnimator.h in Headers */,
-				CB3E5BA9EB9ADCA8AB647F7DC2881D6B /* PVGTableViewRenderCommand.h in Headers */,
-				1BC7C9D26650802A909E6EF8515FF6C5 /* PVGTableViewScrollCommand.h in Headers */,
-				761EFAA064C113141AB9D0283F80C0CC /* PVGTableViewSection.h in Headers */,
-				932F848B894C4D02BF2EA23FBF3C7C14 /* PVGTableViewSectionHeader.h in Headers */,
-				52EE0FD2DF4325A5D47249E4EBE6C17A /* PVGTableViewSectionHeaderViewModel.h in Headers */,
-				30501E4C88F541CF0E2031201CB50F67 /* PVGTableViewSimpleDataSource.h in Headers */,
+				43303FA0E16C4B661CA9CF1D74BA6DFB /* NSInvocation+OCMAdditions.h in Headers */,
+				B9857724CC44E0ADDB1AB9CFFB7DC8D0 /* NSMethodSignature+OCMAdditions.h in Headers */,
+				1E82318C960EA186382BBC8BB2C0266F /* NSNotificationCenter+OCMAdditions.h in Headers */,
+				9A5BC5B1AFA52DABB286A19D6E767626 /* NSObject+OCMAdditions.h in Headers */,
+				BF1CA3ED00A95824C1D0BAE7AABD217B /* NSValue+OCMAdditions.h in Headers */,
+				BA45B33961412E113D7AEE437AEABD6A /* OCClassMockObject.h in Headers */,
+				6E78E75465C6293C7CE4DE94A9F2C4A5 /* OCMArg.h in Headers */,
+				E33075E208008574A3411584C70428CD /* OCMArgAction.h in Headers */,
+				C88CB4F610E9847F915E7737B22DE446 /* OCMBlockArgCaller.h in Headers */,
+				A209CA747BF54A00F3ACA7B8A7415318 /* OCMBlockCaller.h in Headers */,
+				425F701EFFB6204C3E7B3D24CD22DCA0 /* OCMBoxedReturnValueProvider.h in Headers */,
+				2289D7DE08C240F4D2AB52F96966C1EA /* OCMConstraint.h in Headers */,
+				99A6FDCF475A77B22FEE4992AFC5C6B8 /* OCMExceptionReturnValueProvider.h in Headers */,
+				175F6329587AF94B1B166F391D557FE7 /* OCMExpectationRecorder.h in Headers */,
+				78E92D6492C69E5FEB48A74FCBCCD75D /* OCMFunctions.h in Headers */,
+				23F1890731EDF45E1F1971337E0EBBDB /* OCMFunctionsPrivate.h in Headers */,
+				2E6AF8C0E5FCCEF9BB933661FF38D582 /* OCMIndirectReturnValueProvider.h in Headers */,
+				08CF41BEB018D1F30D39B5EB10DBFC88 /* OCMInvocationExpectation.h in Headers */,
+				E5B9C6476DC0B4CC8FB94117E83942BC /* OCMInvocationMatcher.h in Headers */,
+				2976825D67AB6716D1AE54BB8CCB833F /* OCMInvocationStub.h in Headers */,
+				A166D011364E50A1D1CB5A7B7BF1662D /* OCMLocation.h in Headers */,
+				1970015CBE9B518ECB589B723C357FD0 /* OCMMacroState.h in Headers */,
+				8A8968FBBB8979EE56713737B842D212 /* OCMNotificationPoster.h in Headers */,
+				4D1DD611F216B0159E1DE747C6D8AF0D /* OCMObserverRecorder.h in Headers */,
+				12167D3E958C487FAF4DFCEB68CDA979 /* OCMPassByRefSetter.h in Headers */,
+				6C44A390631152F5F8BFDE26AAC057A3 /* OCMRealObjectForwarder.h in Headers */,
+				B713877003BE6C530457091A7CDAAC59 /* OCMRecorder.h in Headers */,
+				31109AD6A330A8BBD6E702FFBA3F1D50 /* OCMReturnValueProvider.h in Headers */,
+				52EE6A5ED20ACEA8AC7FCB1DC2D67EA5 /* OCMStubRecorder.h in Headers */,
+				26C6368B41ED48224C70567BA92D860F /* OCMVerifier.h in Headers */,
+				163CBB06079ACB78C13BD6EADBDEA549 /* OCMock.h in Headers */,
+				449FCD185192C1FEDEB84AAA0D876F16 /* OCMockObject.h in Headers */,
+				85AC2EB9B365C77490E734209856E3D0 /* OCObserverMockObject.h in Headers */,
+				04777763BA6EA4DAD9E28772AA89BF22 /* OCPartialMockObject.h in Headers */,
+				8376BA13C74C781A4BF0618BE199D66B /* OCProtocolMockObject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1296,40 +1296,22 @@
 			buildRules = (
 			);
 			dependencies = (
-				8722F9ACFC2BD184204EBCF97C2F4BC2 /* PBXTargetDependency */,
-				BEBD73177CC80E09FB00DFD598A5CDA5 /* PBXTargetDependency */,
-				0322286331BD343C765B380FE575A817 /* PBXTargetDependency */,
+				6889C057612B5252D7DC58313AEEDA79 /* PBXTargetDependency */,
+				EB29B49E90AFE51B8EF74512D1492C38 /* PBXTargetDependency */,
+				846344C03463C224EEF90FFD9901CCBA /* PBXTargetDependency */,
 			);
 			name = "Pods-ios";
 			productName = "Pods-ios";
 			productReference = 89F741FB0B205AEE49FBE3B16CE52A46 /* libPods-ios.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		4605D3A79D4D4065E5824B51B1F59438 /* PVGTableViewProxy */ = {
+		3CE42A70E6AB364CFC64E633F663BCC4 /* OCMock */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B34FA26E971307D2958853530EBF0DD3 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */;
+			buildConfigurationList = 2C12935C92AABBAC7EC464A869FDCB7C /* Build configuration list for PBXNativeTarget "OCMock" */;
 			buildPhases = (
-				164D6E58337D95920DFB6B8D275CCE0E /* Sources */,
-				02E08C3B6B41FA00DFD940E217C06940 /* Frameworks */,
-				695FFD61CA64F4FB0D32301DC88FBA73 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				47C34909EA4ED63594CB605F6DC1106A /* PBXTargetDependency */,
-			);
-			name = PVGTableViewProxy;
-			productName = PVGTableViewProxy;
-			productReference = FCFFB082D20FD540A8432470FE0FD0A0 /* libPVGTableViewProxy.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		CDE88E0D36B79134D5D549BEFD328433 /* OCMock */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 10F5C5DBA485D355DA126831950C52E3 /* Build configuration list for PBXNativeTarget "OCMock" */;
-			buildPhases = (
-				8A1B1E3D0B3AE03EF1D5CB05D30DAFE0 /* Sources */,
-				276946C88320922FBDB5CF2473F9B5DD /* Frameworks */,
-				1D8565E5271018890A9817F4BEABEADB /* Headers */,
+				0C3DDBB399B3A450D9B036E419271895 /* Sources */,
+				991C652C4742DD7D945A90F3EFE3A898 /* Frameworks */,
+				8A2BEAA4BD7BC6595E4A739298C62BE7 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1337,7 +1319,25 @@
 			);
 			name = OCMock;
 			productName = OCMock;
-			productReference = 3CD190E1B287D46CB8B84BA505D3D283 /* libOCMock.a */;
+			productReference = AE524CE6151000ACB3FDE5AA646B3215 /* libOCMock.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		D2B52569AD117BAD7C6F9E4C8EE15975 /* PVGTableViewProxy */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1AED2EA151E005DA387934E2E1C5AA1 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */;
+			buildPhases = (
+				8BB6F8354D646E678D7B0265D485E576 /* Sources */,
+				510C22C2EBEECA2F3A979BAB0126CF8D /* Frameworks */,
+				57DABD14C73C536B7840E9005E4C9A3A /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				355CBE84999FECC3D02E00A1DBC21F1C /* PBXTargetDependency */,
+			);
+			name = PVGTableViewProxy;
+			productName = PVGTableViewProxy;
+			productReference = FE4F2BC66481B9EDAB216C8BA440EDFC /* libPVGTableViewProxy.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */ = {
@@ -1378,8 +1378,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CDE88E0D36B79134D5D549BEFD328433 /* OCMock */,
-				4605D3A79D4D4065E5824B51B1F59438 /* PVGTableViewProxy */,
+				3CE42A70E6AB364CFC64E633F663BCC4 /* OCMock */,
+				D2B52569AD117BAD7C6F9E4C8EE15975 /* PVGTableViewProxy */,
 				108223BF676BC2589DFCF942C06FB7CD /* Pods-ios */,
 				D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */,
 			);
@@ -1395,60 +1395,60 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		164D6E58337D95920DFB6B8D275CCE0E /* Sources */ = {
+		0C3DDBB399B3A450D9B036E419271895 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2A4DCD6C637F48CE69FFBD9C9A865C2C /* PVGGenericTableViewProxyAnimator.m in Sources */,
-				5E8230DEC6B6D73F84C2B956555E9BDF /* PVGNoAnimationTableViewProxyAnimator.m in Sources */,
-				A84E09241E0C52206DE681A9DA3CA614 /* PVGTableViewProxy-dummy.m in Sources */,
-				C49137240873DF3A2C4F093238747790 /* PVGTableViewProxy.m in Sources */,
-				901F8BFAB0E2F17BAF42BF79C2D46FA5 /* PVGTableViewRenderCommand.m in Sources */,
-				22959BF5C2F33FB5A0ABA239E3FBFE91 /* PVGTableViewScrollCommand.m in Sources */,
-				242AEF7303BAE66D84C57C731D946787 /* PVGTableViewSection.m in Sources */,
-				E1ECAE9EE0D97CCC4A2B0CA331ADA441 /* PVGTableViewSectionHeaderViewModel.m in Sources */,
-				D25E1F6864F822D7F9F56D3CB1A5F551 /* PVGTableViewSimpleDataSource.m in Sources */,
+				8372D00F71C8289F5BC0EFA3BC4E2ED9 /* NSInvocation+OCMAdditions.m in Sources */,
+				A3F4D398ACCEE24CA1588CB224C01ED9 /* NSMethodSignature+OCMAdditions.m in Sources */,
+				8E87685B9115815C662318299F6277CB /* NSNotificationCenter+OCMAdditions.m in Sources */,
+				90BB51EEF69BB0BC3EF414C9701041B4 /* NSObject+OCMAdditions.m in Sources */,
+				70A7B1DAFA4427EB69A7D08B3F729F83 /* NSValue+OCMAdditions.m in Sources */,
+				360973D2CF7133E6674C913F186A0D76 /* OCClassMockObject.m in Sources */,
+				5247A1E231F23050B8EF4D005937D700 /* OCMArg.m in Sources */,
+				2FC379687B39959B83EA9957E0216DA6 /* OCMArgAction.m in Sources */,
+				6A10FBA8E2619C433C6BBA1CB85CCB3F /* OCMBlockArgCaller.m in Sources */,
+				D0C91D823CCB007BA70D8A8B221BCFEF /* OCMBlockCaller.m in Sources */,
+				2DAC60F7A5CDE44A296357C599775350 /* OCMBoxedReturnValueProvider.m in Sources */,
+				2C1A0AEEB1491455D0F8B335097BB5C4 /* OCMConstraint.m in Sources */,
+				7414994301A906E1880330724A8DFA86 /* OCMExceptionReturnValueProvider.m in Sources */,
+				7FE1B6A2485DDCFE7E8C71DA8874E55F /* OCMExpectationRecorder.m in Sources */,
+				9D063125F6E11B22B6D21E79B11BF390 /* OCMFunctions.m in Sources */,
+				5DF1B32F5D2F818DDDEB20BBF566FCA8 /* OCMIndirectReturnValueProvider.m in Sources */,
+				9CBADA3A40BDF4E5B4BC506EED0B9F3C /* OCMInvocationExpectation.m in Sources */,
+				82035AD6BC75984F1FC671F43DCE693E /* OCMInvocationMatcher.m in Sources */,
+				096C88AA5B79B6C58E92864923CC2C2A /* OCMInvocationStub.m in Sources */,
+				929A5E56599DA116B46C9325A4C95E74 /* OCMLocation.m in Sources */,
+				9A43B5BF2FF9120B0D472E63D73C23FF /* OCMMacroState.m in Sources */,
+				812EADFBFFF7E9597FAE47E280B954F6 /* OCMNotificationPoster.m in Sources */,
+				FCB357B6F774F753DA7E70A627631535 /* OCMObserverRecorder.m in Sources */,
+				2598C8252104462029D576EA330A520F /* OCMPassByRefSetter.m in Sources */,
+				121A806FFD0344CC4BC753D70E9D6242 /* OCMRealObjectForwarder.m in Sources */,
+				3755EF45DFBF563B4CA1BA8B3B4ECC36 /* OCMRecorder.m in Sources */,
+				B3EE2CF41A058561AFEA52FE6249FC86 /* OCMReturnValueProvider.m in Sources */,
+				B8DE44D4FA5254615B40920CC5E32F27 /* OCMStubRecorder.m in Sources */,
+				D4F809187FA52BB0957B0B9847B737BB /* OCMVerifier.m in Sources */,
+				C1630C99F66538705555CB4D51BBB811 /* OCMock-dummy.m in Sources */,
+				7F443CC5A462EF1B13062EA3130C6949 /* OCMockObject.m in Sources */,
+				97F7369E1CD96687025F9B3D8D340FC7 /* OCObserverMockObject.m in Sources */,
+				1B4B0BCF62D40AC14C16F750E8A93D9D /* OCPartialMockObject.m in Sources */,
+				487F68EC0D6128F1325746E691757270 /* OCProtocolMockObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8A1B1E3D0B3AE03EF1D5CB05D30DAFE0 /* Sources */ = {
+		8BB6F8354D646E678D7B0265D485E576 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				750B0AB5396B94F10D8B020993A8111B /* NSInvocation+OCMAdditions.m in Sources */,
-				60D41D18CE947ABD68A9045084D144D6 /* NSMethodSignature+OCMAdditions.m in Sources */,
-				8BA999615D0AA2A86F7A88CF3E7BAB06 /* NSNotificationCenter+OCMAdditions.m in Sources */,
-				7BF72B890477CCB191A67FC1946FA5D8 /* NSObject+OCMAdditions.m in Sources */,
-				4943516AD811FE9E08C0F6CA611F1B9D /* NSValue+OCMAdditions.m in Sources */,
-				B9DD0C572B277805C01E94F79B3B5E84 /* OCClassMockObject.m in Sources */,
-				045430349CD69DCBE76D80768670DCFB /* OCMArg.m in Sources */,
-				D5D38BA0BA8BD29DFF4244737895C9CD /* OCMArgAction.m in Sources */,
-				D6791052A919FE2BC6775A6046872464 /* OCMBlockArgCaller.m in Sources */,
-				AED29BA336356D4AE2EC820E6E5BC4E2 /* OCMBlockCaller.m in Sources */,
-				E5FE3B82FE89DF337DE94435AFCA63E7 /* OCMBoxedReturnValueProvider.m in Sources */,
-				D2D97E132174477B91FEEE6E6FF1FA40 /* OCMConstraint.m in Sources */,
-				929BA2448BEBD151A7286FAF36547F44 /* OCMExceptionReturnValueProvider.m in Sources */,
-				10DB0173EAC05EE5DA0D3F5BA992F009 /* OCMExpectationRecorder.m in Sources */,
-				CD7ABDEB1B37867ABBBB54577BAB2F66 /* OCMFunctions.m in Sources */,
-				F07C72F58E6ED099168F495D2D1707F7 /* OCMIndirectReturnValueProvider.m in Sources */,
-				7792DE91DA902F175C30A80AA39F18F4 /* OCMInvocationExpectation.m in Sources */,
-				5A7F4111FDE893DB25BDBEBB2A25263F /* OCMInvocationMatcher.m in Sources */,
-				28CD7B74D5E4EBDAA8848D92406D0249 /* OCMInvocationStub.m in Sources */,
-				A0F6F9CD05502DA42A6A40A7EB0A357F /* OCMLocation.m in Sources */,
-				68E07311952A0369BE758F81D9EF2179 /* OCMMacroState.m in Sources */,
-				A17984E76AD5F4BB3E1CF5BE91FCCB41 /* OCMNotificationPoster.m in Sources */,
-				1F8BF4C2F5A89E5E3AC7C65277C38F2D /* OCMObserverRecorder.m in Sources */,
-				1349708AD35911009C7C7866BD5DA176 /* OCMPassByRefSetter.m in Sources */,
-				3C5AF4C91BEEE9E96F93237F54141ADA /* OCMRealObjectForwarder.m in Sources */,
-				A4670D4614112A8DC7B2104AEAC93F18 /* OCMRecorder.m in Sources */,
-				E79C3C5B1AA9A34A07F540C9728BF74B /* OCMReturnValueProvider.m in Sources */,
-				08DE9EFDE4D1721F7660DF1F3E7CDE59 /* OCMStubRecorder.m in Sources */,
-				175DDDBE53D332CDF19FC7B07EE454F4 /* OCMVerifier.m in Sources */,
-				08E9225BDD4E6A9E759F2A45B119DA16 /* OCMock-dummy.m in Sources */,
-				65A8C260690014E7CB47BADA931BCFE5 /* OCMockObject.m in Sources */,
-				BF87503F46376297E2190506A87409DE /* OCObserverMockObject.m in Sources */,
-				9099F8E7A76EBB0D24C95CCCC77374DB /* OCPartialMockObject.m in Sources */,
-				406AE0AFC913250B2DE2A972ED596DAE /* OCProtocolMockObject.m in Sources */,
+				C62590EA14C07F3C92FA4EC5EAA57259 /* PVGGenericTableViewProxyAnimator.m in Sources */,
+				E154D2F83C5C127905CA701EBBF03545 /* PVGNoAnimationTableViewProxyAnimator.m in Sources */,
+				B4E3F85CC26EB5EA9E3424554309C8BC /* PVGTableViewProxy-dummy.m in Sources */,
+				37F4694F89D7E7E6089CCE2E08AA562E /* PVGTableViewProxy.m in Sources */,
+				9BA10182C81C1BD22A8FFB468F7467E8 /* PVGTableViewRenderCommand.m in Sources */,
+				CC05D18E18D8F4158F8A2F9F76BA4E2D /* PVGTableViewScrollCommand.m in Sources */,
+				DD9F19A9C50B79BA79402EC31812C7A6 /* PVGTableViewSection.m in Sources */,
+				F3DBABB779292CD3415E62B3BADCAEB5 /* PVGTableViewSectionHeaderViewModel.m in Sources */,
+				55DAA752E6A1EACF9B03F9191F970E4C /* PVGTableViewSimpleDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1553,29 +1553,29 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0322286331BD343C765B380FE575A817 /* PBXTargetDependency */ = {
+		355CBE84999FECC3D02E00A1DBC21F1C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ReactiveCocoa;
 			target = D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */;
-			targetProxy = 95034FEA22AEBF59775543E4909D8695 /* PBXContainerItemProxy */;
+			targetProxy = A738FCAA689FD5F2465C3EC051D1986D /* PBXContainerItemProxy */;
 		};
-		47C34909EA4ED63594CB605F6DC1106A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ReactiveCocoa;
-			target = D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */;
-			targetProxy = A952B0BCDFD702755EAF0A6B3818313D /* PBXContainerItemProxy */;
-		};
-		8722F9ACFC2BD184204EBCF97C2F4BC2 /* PBXTargetDependency */ = {
+		6889C057612B5252D7DC58313AEEDA79 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = OCMock;
-			target = CDE88E0D36B79134D5D549BEFD328433 /* OCMock */;
-			targetProxy = 9893A5B45552656093930C26A422BCE8 /* PBXContainerItemProxy */;
+			target = 3CE42A70E6AB364CFC64E633F663BCC4 /* OCMock */;
+			targetProxy = 3BF0F37C59AC54C4985691D01ABBAAB0 /* PBXContainerItemProxy */;
 		};
-		BEBD73177CC80E09FB00DFD598A5CDA5 /* PBXTargetDependency */ = {
+		846344C03463C224EEF90FFD9901CCBA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ReactiveCocoa;
+			target = D76319C99A3017CFE90D0DE010012BAD /* ReactiveCocoa */;
+			targetProxy = 9F2EDBD27857F90D2F9BF478E6BFE842 /* PBXContainerItemProxy */;
+		};
+		EB29B49E90AFE51B8EF74512D1492C38 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PVGTableViewProxy;
-			target = 4605D3A79D4D4065E5824B51B1F59438 /* PVGTableViewProxy */;
-			targetProxy = 2233C5BFE78B3CE4D9C34FE28DC58559 /* PBXContainerItemProxy */;
+			target = D2B52569AD117BAD7C6F9E4C8EE15975 /* PVGTableViewProxy */;
+			targetProxy = 7F424D5B33724B031218C1B5FC94DEBD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1630,12 +1630,12 @@
 			};
 			name = Release;
 		};
-		1A37F6CC7C39C570C03A873BBB73E2ED /* Release */ = {
+		32B48BADD5E3027E00ECAEB79FC4C128 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7B7ED8A1DEE24AF49D10AF61C1FD49DA /* PVGTableViewProxy-Private.xcconfig */;
+			baseConfigurationReference = E3C7D0B2B410E8BD185A26272B5544F7 /* OCMock-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/OCMock/OCMock-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
@@ -1662,12 +1662,12 @@
 			};
 			name = Debug;
 		};
-		73C2F8B897A46F69E700E38F2A7F27A9 /* Debug */ = {
+		770834E245BF37DE15041026E97BB034 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C75433977EE2507B5E0E441F367E3B19 /* OCMock-Private.xcconfig */;
+			baseConfigurationReference = 0847F72083B2F953FB11CD003921B2E8 /* ReactiveCocoa-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/OCMock/OCMock-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/ReactiveCocoa/ReactiveCocoa-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
@@ -1678,12 +1678,12 @@
 			};
 			name = Debug;
 		};
-		770834E245BF37DE15041026E97BB034 /* Debug */ = {
+		9E6A029FFE587BD0A6B127CB75139A62 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0847F72083B2F953FB11CD003921B2E8 /* ReactiveCocoa-Private.xcconfig */;
+			baseConfigurationReference = E3C7D0B2B410E8BD185A26272B5544F7 /* OCMock-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/ReactiveCocoa/ReactiveCocoa-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/OCMock/OCMock-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
@@ -1749,25 +1749,9 @@
 			};
 			name = Debug;
 		};
-		C32C2A8E45D03F8AF078C77788983DC8 /* Release */ = {
+		CDA6DAAD6B56F02174D830265CC14B22 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C75433977EE2507B5E0E441F367E3B19 /* OCMock-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/OCMock/OCMock-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		E2D9D89552807E40C53910BBE48BB4CC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7B7ED8A1DEE24AF49D10AF61C1FD49DA /* PVGTableViewProxy-Private.xcconfig */;
+			baseConfigurationReference = 24B0F3D2E21AAEC48B2FC12808AF2DC7 /* PVGTableViewProxy-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
@@ -1781,6 +1765,22 @@
 			};
 			name = Debug;
 		};
+		DA3F73614C07BE2721D0933D4EC33424 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 24B0F3D2E21AAEC48B2FC12808AF2DC7 /* PVGTableViewProxy-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/PVGTableViewProxy/PVGTableViewProxy-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1793,11 +1793,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		10F5C5DBA485D355DA126831950C52E3 /* Build configuration list for PBXNativeTarget "OCMock" */ = {
+		2C12935C92AABBAC7EC464A869FDCB7C /* Build configuration list for PBXNativeTarget "OCMock" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				73C2F8B897A46F69E700E38F2A7F27A9 /* Debug */,
-				C32C2A8E45D03F8AF078C77788983DC8 /* Release */,
+				9E6A029FFE587BD0A6B127CB75139A62 /* Debug */,
+				32B48BADD5E3027E00ECAEB79FC4C128 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1820,11 +1820,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B34FA26E971307D2958853530EBF0DD3 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */ = {
+		E1AED2EA151E005DA387934E2E1C5AA1 /* Build configuration list for PBXNativeTarget "PVGTableViewProxy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E2D9D89552807E40C53910BBE48BB4CC /* Debug */,
-				1A37F6CC7C39C570C03A873BBB73E2ED /* Release */,
+				CDA6DAAD6B56F02174D830265CC14B22 /* Debug */,
+				DA3F73614C07BE2721D0933D4EC33424 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tests/Pods/Pods.xcodeproj/xcshareddata/xcschemes/PVGTableViewProxy.xcscheme
+++ b/Tests/Pods/Pods.xcodeproj/xcshareddata/xcschemes/PVGTableViewProxy.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "375F9140D02FC2690FE18190"
+               BlueprintIdentifier = "97F4A5978BC68CD511664531"
                BuildableName = "libPVGTableViewProxy.a"
                BlueprintName = "PVGTableViewProxy"
                ReferencedContainer = "container:Pods.xcodeproj">

--- a/Tests/Tests/TableViewProxyRenderTests.m
+++ b/Tests/Tests/TableViewProxyRenderTests.m
@@ -26,14 +26,12 @@
 
 @implementation TableViewProxyRenderTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
 - (void)test_when_there_are_no_ongoing_scroll_animations_execute_render_will_update_the_table_view
 {
-    NSArray *viewModels = @[OCMProtocolMock(@protocol(PVGTableViewCellViewModel))];
+    id mockViewModel = OCMProtocolMock(@protocol(PVGTableViewCellViewModel));
+    OCMStub([mockViewModel uniqueID]).andReturn(@"uuid");
+    
+    NSArray *viewModels = @[mockViewModel];
     PVGTableViewSimpleDataSource *dataSource = [PVGTableViewSimpleDataSource dataSourceWithViewModels:[RACSignal return:viewModels]];
     PVGTableViewSection *section = [PVGTableViewSection sectionWithDataSource:dataSource];
     


### PR DESCRIPTION
Adding objects with the same unique ids crashes UITableView
with NSInternalInconsistencyException.

E.g.
```
Terminating app due to uncaught exception
 'NSInternalInconsistencyException', reason: 'Invalid update: invalid number of rows in section 0.
 The number of rows contained in an existing section after the update (13) must be equal to the 
number of rows contained in that section before the update (9), plus or minus the number of rows 
inserted or deleted from that section (7 inserted, 6 deleted) and plus or minus the number of rows 
moved into or out of that section (0 moved in, 0 moved out).'
```