### PR TITLE
Update ReactiveCocoa dependency to 4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode7.3
 sudo: false
 env:
   global:
   - LC_CTYPE=en_US.UTF-8
   - LANG=en_US.UTF-8
   matrix:
-    - DESTINATION="OS=9.0,name=iPhone 6 Plus" TEST_SCHEME="Tests" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 4S" TEST_SCHEME="Tests" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="YES"
-    - DESTINATION="OS=9.0,name=iPhone 5" TEST_SCHEME="Tests" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 5S" TEST_SCHEME="Tests" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 6" TEST_SCHEME="Tests" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPad Air 2" TEST_SCHEME="Tests" SDK=iphonesimulator9.0 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.3,name=iPhone 6 Plus" TEST_SCHEME="Tests" SDK=iphonesimulator9.3 RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
+    - DESTINATION="OS=9.3,name=iPhone 4S" TEST_SCHEME="Tests" SDK=iphonesimulator9.3 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="YES"
+    - DESTINATION="OS=9.3,name=iPhone 5" TEST_SCHEME="Tests" SDK=iphonesimulator9.3 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.3,name=iPhone 5S" TEST_SCHEME="Tests" SDK=iphonesimulator9.3 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.3,name=iPhone 6" TEST_SCHEME="Tests" SDK=iphonesimulator9.3 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
+    - DESTINATION="OS=9.3,name=iPad Air 2" TEST_SCHEME="Tests" SDK=iphonesimulator9.3 RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
     
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,23 @@
-#Release 0.3.1
+#Release 1.0.0
 
-Removed PVGTableViewCellWithCollectionViewModel protocol
-Added nullability annotations
-Fixes project settings
++ Upgraded dependency on ReactiveCocoa to 4.1.0.
++ Bumped minimum platform to iOS 8.0.
 
-#Release 0.3.0
+# Release 0.3.1
 
-Adds protection in PVGTableViewProxy against multiple
-view models having the same unique id. 
-The implementation removes the extra view models silently.
++ Removed PVGTableViewCellWithCollectionViewModel protocol
++ Added nullability annotations
++ Fixes project settings
 
-#Release 0.2.1
+# Release 0.3.0
 
-Reverted rendering method back to a synchronous one to fix unwanted animations on UITableView. 
-Made sure that loadMore is called asyncronously to prevent regression with pagination.
++ Adds protection in PVGTableViewProxy against multiple view models having the same unique id. The implementation removes the extra view models silently.
+
+# Release 0.2.1
+
++ Reverted rendering method back to a synchronous one to fix unwanted animations on UITableView. 
++ Made sure that loadMore is called asyncronously to prevent regression with pagination.
 
 # Relase 0.2.0
 
-Replaces NSTimer runloop with dispatch async to fix
-rendering of multiple sections.
++ Replaces NSTimer runloop with dispatch async to fix rendering of multiple sections.

--- a/Example/PVGTableViewProxyExample.xcodeproj/project.pbxproj
+++ b/Example/PVGTableViewProxyExample.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		6003F598195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F596195388D20070C39A /* InfoPlist.strings */; };
 		6003F59A195388D20070C39A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F599195388D20070C39A /* main.m */; };
 		6003F59E195388D20070C39A /* PVGAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F59D195388D20070C39A /* PVGAppDelegate.m */; };
-		97B753C1ACD0E1AABCFD5603 /* libPods-PVGTableViewProxyExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BA09E20BE89F07C87947109 /* libPods-PVGTableViewProxyExample.a */; };
+		EE3626349CAEB0614D73DCD2 /* Pods_PVGTableViewProxyExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F440A9C208CAFE221BD113DE /* Pods_PVGTableViewProxyExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -95,11 +95,11 @@
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		62EAA9A0C72CF01530BF8DE9 /* TableViewProxy.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TableViewProxy.podspec; path = ../TableViewProxy.podspec; sourceTree = "<group>"; };
 		7B347A9C694FC2294C88A727 /* Pods-TableViewProxy_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TableViewProxy_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-TableViewProxy_Example/Pods-TableViewProxy_Example.release.xcconfig"; sourceTree = "<group>"; };
-		8BA09E20BE89F07C87947109 /* libPods-PVGTableViewProxyExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PVGTableViewProxyExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9685B49376977BEBBB1F105B /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		B2EF790AA24CB6FA57EEB04A /* Pods-TableViewProxy_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TableViewProxy_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TableViewProxy_Tests/Pods-TableViewProxy_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		BC49E348B94DC171E0AAE247 /* libPods-TableViewProxy_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TableViewProxy_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D082F3EC39B10A707E11A636 /* libPods-TableViewProxy_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TableViewProxy_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F440A9C208CAFE221BD113DE /* Pods_PVGTableViewProxyExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PVGTableViewProxyExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,7 +110,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				97B753C1ACD0E1AABCFD5603 /* libPods-PVGTableViewProxyExample.a in Frameworks */,
+				EE3626349CAEB0614D73DCD2 /* Pods_PVGTableViewProxyExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,7 +201,7 @@
 				6003F5AF195388D20070C39A /* XCTest.framework */,
 				BC49E348B94DC171E0AAE247 /* libPods-TableViewProxy_Example.a */,
 				D082F3EC39B10A707E11A636 /* libPods-TableViewProxy_Tests.a */,
-				8BA09E20BE89F07C87947109 /* libPods-PVGTableViewProxyExample.a */,
+				F440A9C208CAFE221BD113DE /* Pods_PVGTableViewProxyExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -446,7 +446,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -479,7 +479,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/Example/PVGTableViewProxyExample.xcodeproj/xcshareddata/xcschemes/TableViewProxy-Example.xcscheme
+++ b/Example/PVGTableViewProxyExample.xcodeproj/xcshareddata/xcschemes/TableViewProxy-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,8 +1,10 @@
 source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, "8.0"
 
 xcodeproj 'PVGTableViewProxyExample'
 workspace '../PVGTableViewProxy'
 inhibit_all_warnings!
+use_frameworks!
 
 target 'PVGTableViewProxyExample', :exclusive => true do
   pod "PVGTableViewProxy", :path => "../"

--- a/Example/TableViewProxy/Cells/DemoCell.h
+++ b/Example/TableViewProxy/Cells/DemoCell.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Jóhann Þ. Bergþórsson. All rights reserved.
 //
 
-#import <PVGTableViewCell.h>
+#import <PVGTableViewProxy/PVGTableViewCell.h>
 
 #import "DemoCellViewModel.h"
 

--- a/Example/TableViewProxy/Cells/DemoCellViewModel.h
+++ b/Example/TableViewProxy/Cells/DemoCellViewModel.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Jóhann Þ. Bergþórsson. All rights reserved.
 //
 
-#import <PVGTableViewCellViewModel.h>
+#import <PVGTableViewProxy/PVGTableViewCellViewModel.h>
 
 FOUNDATION_EXPORT NSString *const DEMO_CELL_REUSE_IDENTIFIER;
 

--- a/Example/TableViewProxy/Cells/ForceUpdateCell.h
+++ b/Example/TableViewProxy/Cells/ForceUpdateCell.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <PVGTableViewCell.h>
+#import <PVGTableViewProxy/PVGTableViewCell.h>
 
 #import "ForceUpdateCellViewModel.h"
 

--- a/Example/TableViewProxy/Cells/ForceUpdateCellViewModel.h
+++ b/Example/TableViewProxy/Cells/ForceUpdateCellViewModel.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Jóhann Þ. Bergþórsson. All rights reserved.
 //
 
-#import <PVGTableViewCellViewModel.h>
+#import <PVGTableViewProxy/PVGTableViewCellViewModel.h>
 
 FOUNDATION_EXPORT NSString *const FORCE_UPDATE_CELL_REUSE_IDENTIFIER;
 

--- a/Example/TableViewProxy/Cells/LoadingCell.h
+++ b/Example/TableViewProxy/Cells/LoadingCell.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Jóhann Þ. Bergþórsson. All rights reserved.
 //
 
-#import <PVGTableViewCell.h>
+#import <PVGTableViewProxy/PVGTableViewCell.h>
 
 #import "LoadingCellViewModel.h"
 

--- a/Example/TableViewProxy/Cells/LoadingCellViewModel.h
+++ b/Example/TableViewProxy/Cells/LoadingCellViewModel.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Jóhann Þ. Bergþórsson. All rights reserved.
 //
 
-#import <PVGTableViewCellViewModel.h>
+#import <PVGTableViewProxy/PVGTableViewCellViewModel.h>
 
 FOUNDATION_EXPORT NSString *const LOADING_CELL_REUSE_IDENTIFIER;
 

--- a/Example/TableViewProxy/View Controllers/ForceUpdateListViewController.m
+++ b/Example/TableViewProxy/View Controllers/ForceUpdateListViewController.m
@@ -10,7 +10,7 @@
 
 #import "ForceUpdateCell.h"
 
-#import <PVGTableViewProxy.h>
+#import <PVGTableViewProxy/PVGTableViewProxy.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 @interface ForceUpdateListViewController ()

--- a/Example/TableViewProxy/View Controllers/InfiniteListViewController.h
+++ b/Example/TableViewProxy/View Controllers/InfiniteListViewController.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "InfiniteListViewModel.h"
-#import <PVGTableViewSimpleDataSource.h>
+#import <PVGTableViewProxy/PVGTableViewSimpleDataSource.h>
 
 @interface InfiniteListViewController : UIViewController<PVGTableViewSimpleDataSourceLoadMoreDelegate>
 

--- a/Example/TableViewProxy/View Controllers/InfiniteListViewController.m
+++ b/Example/TableViewProxy/View Controllers/InfiniteListViewController.m
@@ -11,7 +11,7 @@
 #import "LoadingCell.h"
 #import "DemoCell.h"
 
-#import <PVGTableViewProxy.h>
+#import <PVGTableViewProxy/PVGTableViewProxy.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 @interface InfiniteListViewController ()

--- a/Example/TableViewProxy/View Controllers/SectionsListViewController.m
+++ b/Example/TableViewProxy/View Controllers/SectionsListViewController.m
@@ -9,7 +9,7 @@
 #import "SectionsListViewController.h"
 
 #import <ReactiveCocoa/ReactiveCocoa.h>
-#import "PVGTableViewProxy.h"
+#import <PVGTableViewProxy/PVGTableViewProxy.h>
 #import "DemoCell.h"
 
 @interface SectionsListViewController ()

--- a/Example/TableViewProxy/View Controllers/StaticListViewController.m
+++ b/Example/TableViewProxy/View Controllers/StaticListViewController.m
@@ -8,7 +8,7 @@
 
 #import "StaticListViewController.h"
 
-#import <PVGTableViewProxy.h>
+#import <PVGTableViewProxy/PVGTableViewProxy.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 #import "DemoCell.h"

--- a/PVGTableViewProxy.podspec
+++ b/PVGTableViewProxy.podspec
@@ -6,8 +6,8 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = {"Jóhann Þ. Bergþórsson" => "johann@plainvanillagames.com", "Hilmar Birgir Ólafsson" => "hilmar@plainvanillagames.com", "Alexander Annas Helgason" => "alliannas@plainvanillagames.com"}
   s.source           = { :git => "https://github.com/plain-vanilla-games/PVGTableViewProxy.git", :tag => s.version.to_s }
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
   s.source_files = 'PVGTableViewProxy'
-  s.dependency 'ReactiveCocoa', '2.4.2'
+  s.dependency 'ReactiveCocoa', '4.1.0'
 end

--- a/PVGTableViewProxy.podspec
+++ b/PVGTableViewProxy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PVGTableViewProxy"
-  s.version          = "0.3.1"
+  s.version          = "1.0.0"
   s.summary          = "A React inspired component to be able to declaratively use UITableView."
   s.homepage         = "https://github.com/plain-vanilla-games/PVGTableViewProxy"
   s.license          = 'MIT'

--- a/Tests/PVGTableViewProxyTests.xcodeproj/project.pbxproj
+++ b/Tests/PVGTableViewProxyTests.xcodeproj/project.pbxproj
@@ -1,378 +1,830 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		021A6D2B1BD67739005215A7 /* TableViewProxyLoadMoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D271BD67739005215A7 /* TableViewProxyLoadMoreTests.m */; };
-		021A6D2C1BD67739005215A7 /* TableViewProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D281BD67739005215A7 /* TableViewProxyTests.m */; };
-		021A6D2D1BD67739005215A7 /* TableViewScrollCommandTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */; };
-		021A6D2E1BD67739005215A7 /* TableViewSectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */; };
-		027C13D71BE1080800C2C8F5 /* TableViewProxyRenderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 027C13D61BE1080800C2C8F5 /* TableViewProxyRenderTests.m */; };
-		02B7B4361BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m in Sources */ = {isa = PBXBuildFile; fileRef = 02B7B4351BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m */; };
-		02BA88EF1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */; };
-		02E62EDE1BD69F1700BF8EC8 /* MockPVGTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 02E62EDD1BD69F1700BF8EC8 /* MockPVGTableViewCell.m */; };
-		B61F4F719C1E4C05EB0C01D1 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F9DC5FE07A91F2EE454AD62E /* libPods-ios.a */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXFileReference section */
-		021A6D1F1BD67725005215A7 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		021A6D231BD67725005215A7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		021A6D271BD67739005215A7 /* TableViewProxyLoadMoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewProxyLoadMoreTests.m; sourceTree = "<group>"; };
-		021A6D281BD67739005215A7 /* TableViewProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewProxyTests.m; sourceTree = "<group>"; };
-		021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewScrollCommandTests.m; sourceTree = "<group>"; };
-		021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewSectionTests.m; sourceTree = "<group>"; };
-		021A6D311BD67975005215A7 /* TestDependencies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestDependencies.h; path = "Test Utils/TestDependencies.h"; sourceTree = "<group>"; };
-		027C13D61BE1080800C2C8F5 /* TableViewProxyRenderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewProxyRenderTests.m; sourceTree = "<group>"; };
-		02B7B4341BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MockPVGTableViewCellViewModelDidSelect.h; path = Mocks/MockPVGTableViewCellViewModelDidSelect.h; sourceTree = "<group>"; };
-		02B7B4351BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MockPVGTableViewCellViewModelDidSelect.m; path = Mocks/MockPVGTableViewCellViewModelDidSelect.m; sourceTree = "<group>"; };
-		02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GenericTableViewProxyAnimatorTests.m; sourceTree = "<group>"; };
-		02E62EDC1BD69F1700BF8EC8 /* MockPVGTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MockPVGTableViewCell.h; path = Mocks/MockPVGTableViewCell.h; sourceTree = "<group>"; };
-		02E62EDD1BD69F1700BF8EC8 /* MockPVGTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MockPVGTableViewCell.m; path = Mocks/MockPVGTableViewCell.m; sourceTree = "<group>"; };
-		02E62EDF1BD69F5500BF8EC8 /* Mocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Mocks.h; path = Mocks/Mocks.h; sourceTree = "<group>"; };
-		1231A2BF4BA450F4905D3C2B /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
-		C2063A94E81FD7005133A6F0 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
-		F9DC5FE07A91F2EE454AD62E /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		021A6D1C1BD67725005215A7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B61F4F719C1E4C05EB0C01D1 /* libPods-ios.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		021A6CF61BD67610005215A7 = {
-			isa = PBXGroup;
-			children = (
-				02E62EDB1BD69EF600BF8EC8 /* Mocks */,
-				021A6D2F1BD6792C005215A7 /* Test Utils */,
-				021A6D201BD67725005215A7 /* Tests */,
-				021A6D071BD676BB005215A7 /* Products */,
-				7A1D4A63593136CD46275CC4 /* Pods */,
-				3977F73CB3549516CA895C1A /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
-		021A6D071BD676BB005215A7 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				021A6D1F1BD67725005215A7 /* Tests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		021A6D201BD67725005215A7 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				02BA88EE1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m */,
-				021A6D231BD67725005215A7 /* Info.plist */,
-				021A6D271BD67739005215A7 /* TableViewProxyLoadMoreTests.m */,
-				027C13D61BE1080800C2C8F5 /* TableViewProxyRenderTests.m */,
-				021A6D281BD67739005215A7 /* TableViewProxyTests.m */,
-				021A6D291BD67739005215A7 /* TableViewScrollCommandTests.m */,
-				021A6D2A1BD67739005215A7 /* TableViewSectionTests.m */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		021A6D2F1BD6792C005215A7 /* Test Utils */ = {
-			isa = PBXGroup;
-			children = (
-				021A6D311BD67975005215A7 /* TestDependencies.h */,
-			);
-			name = "Test Utils";
-			sourceTree = "<group>";
-		};
-		02E62EDB1BD69EF600BF8EC8 /* Mocks */ = {
-			isa = PBXGroup;
-			children = (
-				02E62EDC1BD69F1700BF8EC8 /* MockPVGTableViewCell.h */,
-				02E62EDD1BD69F1700BF8EC8 /* MockPVGTableViewCell.m */,
-				02E62EDF1BD69F5500BF8EC8 /* Mocks.h */,
-				02B7B4341BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.h */,
-				02B7B4351BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m */,
-			);
-			name = Mocks;
-			sourceTree = "<group>";
-		};
-		3977F73CB3549516CA895C1A /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F9DC5FE07A91F2EE454AD62E /* libPods-ios.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		7A1D4A63593136CD46275CC4 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				C2063A94E81FD7005133A6F0 /* Pods-ios.debug.xcconfig */,
-				1231A2BF4BA450F4905D3C2B /* Pods-ios.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		021A6D1E1BD67725005215A7 /* Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 021A6D241BD67725005215A7 /* Build configuration list for PBXNativeTarget "Tests" */;
-			buildPhases = (
-				8CD036E609FA74E6683F7C03 /* Check Pods Manifest.lock */,
-				021A6D1B1BD67725005215A7 /* Sources */,
-				021A6D1C1BD67725005215A7 /* Frameworks */,
-				021A6D1D1BD67725005215A7 /* Resources */,
-				5028CFB1104DDA7832CE5DB8 /* Copy Pods Resources */,
-				A076D9D1C866FD45C6BB252F /* Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Tests;
-			productName = Tests;
-			productReference = 021A6D1F1BD67725005215A7 /* Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		021A6CF71BD67610005215A7 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastUpgradeCheck = 0700;
-				TargetAttributes = {
-					021A6D1E1BD67725005215A7 = {
-						CreatedOnToolsVersion = 7.0.1;
-					};
-				};
-			};
-			buildConfigurationList = 021A6CFA1BD67610005215A7 /* Build configuration list for PBXProject "PVGTableViewProxyTests" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 021A6CF61BD67610005215A7;
-			productRefGroup = 021A6D071BD676BB005215A7 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				021A6D1E1BD67725005215A7 /* Tests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		021A6D1D1BD67725005215A7 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		5028CFB1104DDA7832CE5DB8 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8CD036E609FA74E6683F7C03 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		A076D9D1C866FD45C6BB252F /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		021A6D1B1BD67725005215A7 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				02B7B4361BD6CC7C0034A4E5 /* MockPVGTableViewCellViewModelDidSelect.m in Sources */,
-				021A6D2D1BD67739005215A7 /* TableViewScrollCommandTests.m in Sources */,
-				02BA88EF1BD7F134007BEF68 /* GenericTableViewProxyAnimatorTests.m in Sources */,
-				021A6D2E1BD67739005215A7 /* TableViewSectionTests.m in Sources */,
-				02E62EDE1BD69F1700BF8EC8 /* MockPVGTableViewCell.m in Sources */,
-				021A6D2C1BD67739005215A7 /* TableViewProxyTests.m in Sources */,
-				027C13D71BE1080800C2C8F5 /* TableViewProxyRenderTests.m in Sources */,
-				021A6D2B1BD67739005215A7 /* TableViewProxyLoadMoreTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin XCBuildConfiguration section */
-		021A6CFB1BD67610005215A7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		021A6CFC1BD67610005215A7 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		021A6D251BD67725005215A7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C2063A94E81FD7005133A6F0 /* Pods-ios.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.plainvanillacorp.Tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		021A6D261BD67725005215A7 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1231A2BF4BA450F4905D3C2B /* Pods-ios.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.plainvanillacorp.Tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		021A6CFA1BD67610005215A7 /* Build configuration list for PBXProject "PVGTableViewProxyTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				021A6CFB1BD67610005215A7 /* Debug */,
-				021A6CFC1BD67610005215A7 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		021A6D241BD67725005215A7 /* Build configuration list for PBXNativeTarget "Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				021A6D251BD67725005215A7 /* Debug */,
-				021A6D261BD67725005215A7 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = 021A6CF71BD67610005215A7 /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>021A6CF61BD67610005215A7</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>02E62EDB1BD69EF600BF8EC8</string>
+				<string>021A6D2F1BD6792C005215A7</string>
+				<string>021A6D201BD67725005215A7</string>
+				<string>021A6D071BD676BB005215A7</string>
+				<string>7A1D4A63593136CD46275CC4</string>
+				<string>3977F73CB3549516CA895C1A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6CF71BD67610005215A7</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastUpgradeCheck</key>
+				<string>0730</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>021A6D1E1BD67725005215A7</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.0.1</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>021A6CFA1BD67610005215A7</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>021A6CF61BD67610005215A7</string>
+			<key>productRefGroup</key>
+			<string>021A6D071BD676BB005215A7</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>021A6D1E1BD67725005215A7</string>
+			</array>
+		</dict>
+		<key>021A6CFA1BD67610005215A7</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>021A6CFB1BD67610005215A7</string>
+				<string>021A6CFC1BD67610005215A7</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>021A6CFB1BD67610005215A7</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_TESTABILITY</key>
+				<string>YES</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>021A6CFC1BD67610005215A7</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict/>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>021A6D071BD676BB005215A7</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>021A6D1F1BD67725005215A7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D1B1BD67725005215A7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>02B7B4361BD6CC7C0034A4E5</string>
+				<string>021A6D2D1BD67739005215A7</string>
+				<string>02BA88EF1BD7F134007BEF68</string>
+				<string>021A6D2E1BD67739005215A7</string>
+				<string>02E62EDE1BD69F1700BF8EC8</string>
+				<string>021A6D2C1BD67739005215A7</string>
+				<string>027C13D71BE1080800C2C8F5</string>
+				<string>021A6D2B1BD67739005215A7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>021A6D1C1BD67725005215A7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>8C53716309BD89F6A8C9CEF1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>021A6D1D1BD67725005215A7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>021A6D1E1BD67725005215A7</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>021A6D241BD67725005215A7</string>
+			<key>buildPhases</key>
+			<array>
+				<string>8CD036E609FA74E6683F7C03</string>
+				<string>021A6D1B1BD67725005215A7</string>
+				<string>021A6D1C1BD67725005215A7</string>
+				<string>021A6D1D1BD67725005215A7</string>
+				<string>5028CFB1104DDA7832CE5DB8</string>
+				<string>A076D9D1C866FD45C6BB252F</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Tests</string>
+			<key>productName</key>
+			<string>Tests</string>
+			<key>productReference</key>
+			<string>021A6D1F1BD67725005215A7</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>021A6D1F1BD67725005215A7</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Tests.xctest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>021A6D201BD67725005215A7</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>02BA88EE1BD7F134007BEF68</string>
+				<string>021A6D231BD67725005215A7</string>
+				<string>021A6D271BD67739005215A7</string>
+				<string>027C13D61BE1080800C2C8F5</string>
+				<string>021A6D281BD67739005215A7</string>
+				<string>021A6D291BD67739005215A7</string>
+				<string>021A6D2A1BD67739005215A7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Tests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D231BD67725005215A7</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D241BD67725005215A7</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>021A6D251BD67725005215A7</string>
+				<string>021A6D261BD67725005215A7</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>021A6D251BD67725005215A7</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>C2063A94E81FD7005133A6F0</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>ENABLE_TESTABILITY</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_NO_COMMON_BLOCKS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Tests/Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>9.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.plainvanillacorp.Tests</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>021A6D261BD67725005215A7</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1231A2BF4BA450F4905D3C2B</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_NO_COMMON_BLOCKS</key>
+				<string>YES</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Tests/Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>9.0</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.plainvanillacorp.Tests</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>021A6D271BD67739005215A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TableViewProxyLoadMoreTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D281BD67739005215A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TableViewProxyTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D291BD67739005215A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TableViewScrollCommandTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D2A1BD67739005215A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TableViewSectionTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D2B1BD67739005215A7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>021A6D271BD67739005215A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>021A6D2C1BD67739005215A7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>021A6D281BD67739005215A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>021A6D2D1BD67739005215A7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>021A6D291BD67739005215A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>021A6D2E1BD67739005215A7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>021A6D2A1BD67739005215A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>021A6D2F1BD6792C005215A7</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>021A6D311BD67975005215A7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Test Utils</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021A6D311BD67975005215A7</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>TestDependencies.h</string>
+			<key>path</key>
+			<string>Test Utils/TestDependencies.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>027C13D61BE1080800C2C8F5</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TableViewProxyRenderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>027C13D71BE1080800C2C8F5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>027C13D61BE1080800C2C8F5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>02B7B4341BD6CC7C0034A4E5</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>MockPVGTableViewCellViewModelDidSelect.h</string>
+			<key>path</key>
+			<string>Mocks/MockPVGTableViewCellViewModelDidSelect.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02B7B4351BD6CC7C0034A4E5</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>MockPVGTableViewCellViewModelDidSelect.m</string>
+			<key>path</key>
+			<string>Mocks/MockPVGTableViewCellViewModelDidSelect.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02B7B4361BD6CC7C0034A4E5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>02B7B4351BD6CC7C0034A4E5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>02BA88EE1BD7F134007BEF68</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>GenericTableViewProxyAnimatorTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02BA88EF1BD7F134007BEF68</key>
+		<dict>
+			<key>fileRef</key>
+			<string>02BA88EE1BD7F134007BEF68</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>02E62EDB1BD69EF600BF8EC8</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>02E62EDC1BD69F1700BF8EC8</string>
+				<string>02E62EDD1BD69F1700BF8EC8</string>
+				<string>02E62EDF1BD69F5500BF8EC8</string>
+				<string>02B7B4341BD6CC7C0034A4E5</string>
+				<string>02B7B4351BD6CC7C0034A4E5</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Mocks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02E62EDC1BD69F1700BF8EC8</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>MockPVGTableViewCell.h</string>
+			<key>path</key>
+			<string>Mocks/MockPVGTableViewCell.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02E62EDD1BD69F1700BF8EC8</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>MockPVGTableViewCell.m</string>
+			<key>path</key>
+			<string>Mocks/MockPVGTableViewCell.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02E62EDE1BD69F1700BF8EC8</key>
+		<dict>
+			<key>fileRef</key>
+			<string>02E62EDD1BD69F1700BF8EC8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>02E62EDF1BD69F5500BF8EC8</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Mocks.h</string>
+			<key>path</key>
+			<string>Mocks/Mocks.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1231A2BF4BA450F4905D3C2B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-ios.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3977F73CB3549516CA895C1A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>5578DCA024A16EA479ECBCE6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5028CFB1104DDA7832CE5DB8</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>5578DCA024A16EA479ECBCE6</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods_ios.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>7A1D4A63593136CD46275CC4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>C2063A94E81FD7005133A6F0</string>
+				<string>1231A2BF4BA450F4905D3C2B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8C53716309BD89F6A8C9CEF1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5578DCA024A16EA479ECBCE6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8CD036E609FA74E6683F7C03</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>A076D9D1C866FD45C6BB252F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Embed Pods Frameworks</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>C2063A94E81FD7005133A6F0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-ios.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>021A6CF71BD67610005215A7</string>
+</dict>
+</plist>

--- a/Tests/PVGTableViewProxyTests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/PVGTableViewProxyTests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -3,13 +3,14 @@ source 'https://github.com/CocoaPods/Specs'
 xcodeproj 'PVGTableViewProxyTests'
 workspace '../PVGTableViewProxy'
 inhibit_all_warnings!
+use_frameworks!
 
 target :ios do
-  platform :ios, '7.0'
+  platform :ios, '8.0'
   link_with 'Tests'
 
   pod 'OCMock', '3.2'
-  pod 'ReactiveCocoa', '2.4.2'
+  pod 'ReactiveCocoa', '4.1.0'
   pod 'PVGTableViewProxy', :path => '../'
 end
 

--- a/Tests/Test Utils/TestDependencies.h
+++ b/Tests/Test Utils/TestDependencies.h
@@ -11,6 +11,6 @@
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
-#import <ReactiveCocoa.h>
+#import <ReactiveCocoa/ReactiveCocoa.h>
 
 #import "Mocks.h"


### PR DESCRIPTION
This updates the ReactiveCocoa dependency to 4.1.0, allowing code that depends on this library to do the same. This is technically a backwards incompatible change because we need to bump the minimum deployment target to 8.0.